### PR TITLE
Optional hydration

### DIFF
--- a/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
@@ -45,7 +45,7 @@ class HydratorGenerator
      *
      * @return \PHPParser_Node[]
      */
-    public function generate(ReflectionClass $originalClass)
+    public function generate(ReflectionClass $originalClass, $options = array())
     {
         $builder   = new ClassBuilder();
 
@@ -67,7 +67,7 @@ class HydratorGenerator
         // step 2: implement new methods and interfaces, extend original class
         $implementor = new PHPParser_NodeTraverser();
 
-        $implementor->addVisitor(new HydratorMethodsVisitor($originalClass));
+        $implementor->addVisitor(new HydratorMethodsVisitor($originalClass, $options));
         $implementor->addVisitor(new ClassExtensionVisitor($originalClass->getName(), $originalClass->getName()));
         $implementor->addVisitor(
             new ClassImplementorVisitor($originalClass->getName(), array('Zend\\Stdlib\\Hydrator\\HydratorInterface'))

--- a/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
@@ -42,10 +42,11 @@ class HydratorGenerator
      * and a map of properties to be used to
      *
      * @param \ReflectionClass $originalClass
+     * @param array $options
      *
      * @return \PHPParser_Node[]
      */
-    public function generate(ReflectionClass $originalClass, $options = array())
+    public function generate(ReflectionClass $originalClass, array $options = array())
     {
         $builder   = new ClassBuilder();
 

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -48,7 +48,7 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
      */
     public function __construct(ReflectionClass $reflectedClass, array $options = array())
     {
-        $this->reflectedClass = $reflectedClass;
+        $this->reflectedClass       = $reflectedClass;
         $this->makeAccessibleProperties();
         $this->makePropertyWriters();
     }
@@ -56,7 +56,8 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
     /**
      * Initialize $accessibleProperties with option OPTION_ALLOWED_PROPERTIES check
      */
-    private function makeAccessibleProperties() {
+    private function makeAccessibleProperties()
+    {
         $this->accessibleProperties = $this->reflectedClass->getProperties(
             (ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_PUBLIC)
             &  ~ReflectionProperty::IS_STATIC
@@ -74,10 +75,16 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
     /**
      * Initialize $propertyWriters with option OPTION_ALLOWED_PROPERTIES check
      */
-    private function makePropertyWriters() {
+    private function makePropertyWriters()
+    {
         foreach ($reflectedClass->getProperties(ReflectionProperty::IS_PRIVATE) as $property) {
             $name = $reflProp->getName();
-            if (! in_array($name, $options[self::OPTION_ALLOWED_PROPERTIES])) {
+            
+            if (isset($options[self::OPTION_ALLOWED_PROPERTIES]) {
+                if (! in_array($name, $options[self::OPTION_ALLOWED_PROPERTIES])) {
+                    $this->propertyWriters[$name] = new PropertyAccessor($property, 'Writer');
+                }
+            } else {
                 $this->propertyWriters[$name] = new PropertyAccessor($property, 'Writer');
             }
         }

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -63,7 +63,10 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
         }
 
         foreach ($reflectedClass->getProperties(ReflectionProperty::IS_PRIVATE) as $property) {
-            $this->propertyWriters[$property->getName()] = new PropertyAccessor($property, 'Writer');
+            $name = $reflProp->getName();
+            if (! in_array($name, $options[self::OPTION_ALLOWED_PROPERTIES])) {
+                $this->propertyWriters[$name] = new PropertyAccessor($property, 'Writer');
+            }
         }
     }
 

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -80,7 +80,7 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
         foreach ($reflectedClass->getProperties(ReflectionProperty::IS_PRIVATE) as $property) {
             $name = $reflProp->getName();
             
-            if (isset($options[self::OPTION_ALLOWED_PROPERTIES]) {
+            if (isset($options[self::OPTION_ALLOWED_PROPERTIES])) {
                 if (! in_array($name, $options[self::OPTION_ALLOWED_PROPERTIES])) {
                     $this->propertyWriters[$name] = new PropertyAccessor($property, 'Writer');
                 }

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -22,6 +22,12 @@ use ReflectionProperty;
 class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
 {
     /**
+		 * When an array of keys is supplied for this option only properties of
+		 * supplied keys will be used
+		 */
+		const OPTION_ALLOWED_PROPERTIES = 'allowedProperties';
+
+    /**
      * @var ReflectionClass
      */
     private $reflectedClass;
@@ -38,8 +44,9 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
 
     /**
      * @param ReflectionClass $reflectedClass
+     * @param array $options
      */
-    public function __construct(ReflectionClass $reflectedClass, $options = array())
+    public function __construct(ReflectionClass $reflectedClass, array $options = array())
     {
         $this->reflectedClass       = $reflectedClass;
         $this->accessibleProperties = $this->reflectedClass->getProperties(
@@ -47,10 +54,10 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
             &  ~ReflectionProperty::IS_STATIC
         );
 
-        if (isset($options['allowProperties'])) {
-            foreach ($this->accessibleProperties as $k => $reflProp) {
-                if (! in_array($reflProp->getName(), $options['allowProperties'])) {
-                    unset($this->accessibleProperties[$k]);
+        if (isset($options[self::OPTION_ALLOWED_PROPERTIES])) {
+            foreach ($this->accessibleProperties as $key => $reflProp) {
+                if (! in_array($reflProp->getName(), $options[self::OPTION_ALLOWED_PROPERTIES])) {
+                    unset($this->accessibleProperties[$key]);
                 }
             }
         }

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -48,7 +48,15 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
      */
     public function __construct(ReflectionClass $reflectedClass, array $options = array())
     {
-        $this->reflectedClass       = $reflectedClass;
+        $this->reflectedClass = $reflectedClass;
+        $this->makeAccessibleProperties();
+        $this->makePropertyWriters();
+    }
+
+    /**
+     * Initialize $accessibleProperties with option OPTION_ALLOWED_PROPERTIES check
+     */
+    private function makeAccessibleProperties() {
         $this->accessibleProperties = $this->reflectedClass->getProperties(
             (ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_PUBLIC)
             &  ~ReflectionProperty::IS_STATIC
@@ -61,7 +69,12 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
                 }
             }
         }
+    }
 
+    /**
+     * Initialize $propertyWriters with option OPTION_ALLOWED_PROPERTIES check
+     */
+    private function makePropertyWriters() {
         foreach ($reflectedClass->getProperties(ReflectionProperty::IS_PRIVATE) as $property) {
             $name = $reflProp->getName();
             if (! in_array($name, $options[self::OPTION_ALLOWED_PROPERTIES])) {

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -108,7 +108,7 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
         $body = '';
 
         foreach ($this->accessibleProperties as $accessibleProperty) {
-            $body .= '$object->'
+            $body .= 'if(isset($data['.var_export($accessibleProperty->getName(), true).'])) $object->'
                 . $accessibleProperty->getName()
                 . ' = $data['
                 . var_export($accessibleProperty->getName(), true)

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -22,10 +22,10 @@ use ReflectionProperty;
 class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
 {
     /**
-		 * When an array of keys is supplied for this option only properties of
-		 * supplied keys will be used
-		 */
-		const OPTION_ALLOWED_PROPERTIES = 'allowedProperties';
+     * When an array of keys is supplied for this option only properties of
+     * supplied keys will be used
+     */
+    const OPTION_ALLOWED_PROPERTIES = 'allowedProperties';
 
     /**
      * @var ReflectionClass

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -49,7 +49,7 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
 
         if (isset($options['allowProperties'])) {
             foreach ($this->accessibleProperties as $k => $reflProp) {
-                if ( !in_array($reflProp->getName(), $options['allowProperties'])) {
+                if (! in_array($reflProp->getName(), $options['allowProperties'])) {
                     unset($this->accessibleProperties[$k]);
                 }
             }

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -51,9 +51,9 @@ class HydratorMethodsVisitor extends PHPParser_NodeVisitorAbstract
             foreach ($this->accessibleProperties as $k => $reflProp) {
                 if ( !in_array($reflProp->getName(), $options['allowProperties'])) {
                     unset($this->accessibleProperties[$k]);
-								}
+                }
             }
-				}
+        }
 
         foreach ($reflectedClass->getProperties(ReflectionProperty::IS_PRIVATE) as $property) {
             $this->propertyWriters[$property->getName()] = new PropertyAccessor($property, 'Writer');

--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -50,7 +50,7 @@ class HydratorFactory
      *
      * @return string
      */
-    public function getHydratorClass()
+    public function getHydratorClass($options = array())
     {
         $inflector         = $this->configuration->getClassNameInflector();
         $realClassName     = $inflector->getUserClassName($this->configuration->getHydratedClassName());
@@ -59,7 +59,7 @@ class HydratorFactory
         if (! class_exists($hydratorClassName) && $this->configuration->doesAutoGenerateProxies()) {
             $generator     = new HydratorGenerator();
             $originalClass = new ReflectionClass($realClassName);
-            $generatedAst  = $generator->generate($originalClass);
+            $generatedAst  = $generator->generate($originalClass, $options);
             $traverser     = new PHPParser_NodeTraverser();
 
             $traverser->addVisitor(new ClassRenamerVisitor($originalClass, $hydratorClassName));

--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -48,9 +48,11 @@ class HydratorFactory
     /**
      * Retrieves the generated hydrator FQCN
      *
+     * @param array $options
+     *
      * @return string
      */
-    public function getHydratorClass($options = array())
+    public function getHydratorClass(array $options = array())
     {
         $inflector         = $this->configuration->getClassNameInflector();
         $realClassName     = $inflector->getUserClassName($this->configuration->getHydratedClassName());

--- a/tests/GeneratedHydratorTest/CodeGenerator/Visitor/HydratorMethodsVisitorTest.php
+++ b/tests/GeneratedHydratorTest/CodeGenerator/Visitor/HydratorMethodsVisitorTest.php
@@ -42,17 +42,44 @@ class HydratorMethodsVisitorTest extends PHPUnit_Framework_TestCase
      *
      * @param string                    $className
      * @param PHPParser_Node_Stmt_Class $classNode
+     * @param string[]                  $properties
      */
-    public function testBasicCodeGeneration($className, PHPParser_Node_Stmt_Class $classNode)
+    public function testBasicCodeGeneration($className, PHPParser_Node_Stmt_Class $classNode, array $properties)
     {
         $visitor = new HydratorMethodsVisitor(new ReflectionClass($className));
 
         /* @var $modifiedAst PHPParser_Node_Stmt_Class */
         $modifiedNode = $visitor->leaveNode($classNode);
 
-        $this->checkMethodExistence('hydrate', $modifiedNode);
-        $this->checkMethodExistence('extract', $modifiedNode);
-        $this->checkMethodExistence('__construct', $modifiedNode);
+        $this->assertMethodExistence('hydrate', $modifiedNode);
+        $this->assertMethodExistence('extract', $modifiedNode);
+        $this->assertMethodExistence('__construct', $modifiedNode);
+        $this->assertContainsPropertyAccessors($modifiedNode, $properties);
+    }
+
+    /**
+     * Tests the Allowed Properties option.
+     *
+     * BaseClass has a public, protected and private property. Normally
+     * `accessibleProperties` would have 2 properties (public & protected) and
+     * `propertyWriters` just one (private).
+     */
+    public function testAllowPropertiesOption() {
+        $visitor = new HydratorMethodsVisitor(
+            new ReflectionClass('GeneratedHydratorTestAsset\\BaseClass'),
+            array(HydratorMethodsVisitor::OPTION_ALLOWED_PROPERTIES => array(
+                'protectedProperty'
+            ))
+        );
+
+        $reflClass = new ReflectionClass($visitor);
+        $reflProperty1 = $reflClass->getProperty('accessibleProperties');
+        $reflProperty1->setAccessible(true);
+        $reflProperty2 = $reflClass->getProperty('propertyWriters');
+        $reflProperty2->setAccessible(true);
+
+        $this->assertCount(1, $reflProperty1->getValue($visitor));
+        $this->assertCount(0, $reflProperty2->getValue($visitor));
     }
 
     /**
@@ -61,9 +88,8 @@ class HydratorMethodsVisitorTest extends PHPUnit_Framework_TestCase
      * @param string                    $methodName
      * @param PHPParser_Node_Stmt_Class $class
      */
-    private function checkMethodExistence($methodName, PHPParser_Node_Stmt_Class $class)
+    private function assertMethodExistence($methodName, PHPParser_Node_Stmt_Class $class)
     {
-
         $members = $class->stmts;
 
         $this->assertCount(
@@ -79,6 +105,62 @@ class HydratorMethodsVisitorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Verifies that the given properties and only the given properties are added to the hydrator logic
+     *
+     * @param PHPParser_Node_Stmt_Class $class
+     * @param array                     $properties
+     */
+    private function assertContainsPropertyAccessors(PHPParser_Node_Stmt_Class $class, array $properties)
+    {
+        $lookupProperties = array_flip($properties);
+
+        foreach ($class->stmts as $method) {
+            if ($method instanceof \PHPParser_Node_Stmt_ClassMethod && $method->name === 'hydrate') {
+                foreach ($method->stmts as $assignment) {
+                    if ($assignment instanceof \PHPParser_Node_Expr_Assign) {
+                        $var = $assignment->var;
+
+                        if ($var instanceof \PHPParser_Node_Expr_PropertyFetch && is_string($var->name)) {
+                            if (! isset($lookupProperties[$var->name])) {
+                                $this->fail(sprintf('Property "%s" should not be hydrated', $var->name));
+                            }
+
+                            unset($lookupProperties[$var->name]);
+                        }
+                    }
+                }
+            }
+
+            if ($method instanceof \PHPParser_Node_Stmt_ClassMethod && $method->name === '__construct') {
+                foreach ($method->stmts as $assignment) {
+                    if ($assignment instanceof \PHPParser_Node_Expr_Assign) {
+                        $var = $assignment->var;
+
+                        if ($var instanceof \PHPParser_Node_Expr_PropertyFetch
+                            && preg_match('/(.*)Writer[a-zA-Z0-9]+/', $var->name, $matches)
+                        ) {
+                            if (! isset($lookupProperties[$matches[1]])) {
+                                $this->fail(sprintf('Property "%s" should not be hydrated', $matches[1]));
+                            }
+
+                            unset($lookupProperties[$matches[1]]);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (empty($lookupProperties)) {
+            return;
+        }
+
+        $this->fail(sprintf(
+            'Could not match following properties in the generated code: %s',
+            var_export(array_flip($lookupProperties), true)
+        ));
+    }
+
+    /**
      * @return \PHPParser_Node[][]
      */
     public function classAstProvider()
@@ -86,13 +168,20 @@ class HydratorMethodsVisitorTest extends PHPUnit_Framework_TestCase
         $parser = new PHPParser_Parser(new PHPParser_Lexer());
 
         $className = UniqueIdentifierGenerator::getIdentifier('Foo');
-        $classCode = 'class ' . $className . ' { private $bar; private $baz; protected $tab;'
+        $classCode = 'class ' . $className . ' { private $bar; private $baz; protected $tab; '
             . 'protected $tar; public $taw; public $tam; }';
 
         eval($classCode);
 
-        return array(
-            array($className, $parser->parse('<?php ' . $classCode)[0]),
-        );
+        $staticClassName = UniqueIdentifierGenerator::getIdentifier('Foo');
+        $staticClassCode = 'class ' . $staticClassName . ' { private static $bar; '
+            . 'protected static $baz; public static $tab; private $taz; }';
+
+        eval($staticClassCode);
+
+        return [
+            [$className, $parser->parse('<?php ' . $classCode)[0], ['bar', 'baz', 'tab', 'tar', 'taw', 'tam']],
+            [$staticClassName, $parser->parse('<?php ' . $staticClassCode)[0], ['taz']],
+        ];
     }
 }


### PR DESCRIPTION
Allows for properties to be skipped when not found in data array.

Some considerations:
1. line length too long
2. double declaration of `var_export($accessibleProperty->getName(), true)`
3. not configurable
4. isset() might not be optimal here, possibly use ternary operator
5. ... ?
