### PR TITLE
Configurable hydrator generator class

### DIFF
--- a/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
@@ -35,7 +35,7 @@ use ReflectionClass;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class HydratorGenerator
+class HydratorGenerator implements HydratorGeneratorInterface
 {
     /**
      * Generates an AST of {@see \PHPParser_Node[]} out of a given reflection class

--- a/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactory.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactory.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace GeneratedHydrator\ClassGenerator;
+
+/**
+ * Factory for the hydrator generator
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ * @license MIT
+ */
+class HydratorGeneratorFactory implements HydratorGeneratorFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createHydratorGenerator()
+    {
+        return new HydratorGenerator;
+    }
+}

--- a/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactoryInterface.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace GeneratedHydrator\ClassGenerator;
+
+/**
+ * Interface for the factory for the hydrator generator
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ * @license MIT
+ */
+interface HydratorGeneratorFactoryInterface
+{
+    /**
+     * Creates a HydratorGenerator
+     *
+     * @return HydratorGeneratorInterface
+     */
+    public function createHydratorGenerator();
+}

--- a/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorInterface.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorInterface.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace GeneratedHydrator\ClassGenerator;
+
+use ReflectionClass;
+
+/**
+ * Interface for the hydrator generator
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ * @license MIT
+ */
+interface HydratorGeneratorInterface
+{
+    /**
+     * Generates an AST of {@see \PHPParser_Node[]} out of a given reflection class
+     *
+     * @param \ReflectionClass $originalClass
+     *
+     * @return \PHPParser_Node[]
+     */
+    public function generate(ReflectionClass $originalClass);
+}

--- a/src/GeneratedHydrator/Configuration.php
+++ b/src/GeneratedHydrator/Configuration.php
@@ -19,6 +19,8 @@
 namespace GeneratedHydrator;
 
 use GeneratedHydrator\Factory\HydratorFactory;
+use GeneratedHydrator\ClassGenerator\HydratorGeneratorFactory;
+use GeneratedHydrator\ClassGenerator\HydratorGeneratorFactoryInterface;
 use CodeGenerationUtils\Autoloader\AutoloaderInterface;
 use CodeGenerationUtils\Autoloader\Autoloader;
 use CodeGenerationUtils\FileLocator\FileLocator;
@@ -71,6 +73,11 @@ class Configuration
      * @var \CodeGenerationUtils\Inflector\ClassNameInflectorInterface|null
      */
     protected $classNameInflector;
+
+    /**
+     * @var \GeneratedHydrator\ClassGenerator\Hydrator\HydratorGeneratorFactoryInterface|null
+     */
+    protected $hydratorGeneratorFactory;
 
     /**
      * @param string $hydratedClassName
@@ -219,5 +226,25 @@ class Configuration
         }
 
         return $this->classNameInflector;
+    }
+
+    /**
+     * @param \GeneratedHydrator\ClassGenerator\HydratorGeneratorFactoryInterface $hydratorGeneratorFactory
+     */
+    public function setHydratorGeneratorFactory(HydratorGeneratorFactoryInterface $hydratorGeneratorFactory)
+    {
+        $this->hydratorGeneratorFactory = $hydratorGeneratorFactory;
+    }
+
+    /**
+     * @return \GeneratedHydrator\ClassGenerator\HydratorGeneratorFactoryInterface
+     */
+    public function getHydratorGeneratorFactory()
+    {
+        if (null === $this->hydratorGeneratorFactory) {
+            $this->hydratorGeneratorFactory = new HydratorGeneratorFactory();
+        }
+
+        return $this->hydratorGeneratorFactory;
     }
 }

--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -57,10 +57,12 @@ class HydratorFactory
         $hydratorClassName = $inflector->getGeneratedClassName($realClassName, array('factory' => get_class($this)));
 
         if (! class_exists($hydratorClassName) && $this->configuration->doesAutoGenerateProxies()) {
-            $generator     = new HydratorGenerator();
-            $originalClass = new ReflectionClass($realClassName);
-            $generatedAst  = $generator->generate($originalClass);
-            $traverser     = new PHPParser_NodeTraverser();
+            $generatorFactory = $this->configuration->getHydratorGeneratorFactory();
+
+            $generator        = $generatorFactory->createHydratorGenerator();
+            $originalClass    = new ReflectionClass($realClassName);
+            $generatedAst     = $generator->generate($originalClass);
+            $traverser        = new PHPParser_NodeTraverser();
 
             $traverser->addVisitor(new ClassRenamerVisitor($originalClass, $hydratorClassName));
 


### PR DESCRIPTION
I'm having a use case where I'd like to use large parts of what the library provides, but I'd like to customize how the hydrator class looks with a custom hydrator generator. In order to do that I created this PR, which adds a bunch of interfaces and factories, so the Configuration class has a HydratorGeneratorFactory instance, which creates the hydrator generator.

This might be a bit heavy handed, since I could just use a closure instead of a factory class, but that's a matter of taste, so I'll leave that up to you, so just let me know if you'd like me to change this to use closures instead.