### PR TITLE
Fix for autoloading not taking place when auto proxy generation is turned

### DIFF
--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -65,8 +65,9 @@ class HydratorFactory
             $traverser->addVisitor(new ClassRenamerVisitor($originalClass, $hydratorClassName));
 
             $this->configuration->getGeneratorStrategy()->generate($traverser->traverse($generatedAst));
-            $this->configuration->getGeneratedClassAutoloader()->__invoke($hydratorClassName);
         }
+
+        $this->configuration->getGeneratedClassAutoloader()->__invoke($hydratorClassName);
 
         return $hydratorClassName;
     }

--- a/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
+++ b/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
@@ -64,30 +64,40 @@ class HydratorFactoryTest extends PHPUnit_Framework_TestCase
      * @covers \GeneratedHydrator\Factory\HydratorFactory::__construct
      * @covers \GeneratedHydrator\Factory\HydratorFactory::getHydratorClass
      */
-    public function testWillSkipAutoGeneration()
+    public function testWillSkipAutoGenerationButStillAutoloadAnExistingGeneratedHydrator()
     {
         $className = UniqueIdentifierGenerator::getIdentifier('foo');
+        $hydratorClassName = 'GeneratedHydratorTestAsset\\EmptyClass';
 
+        $autoloader = $this->getMock('CodeGenerationUtils\\Autoloader\\AutoloaderInterface');
+        $autoloader
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($hydratorClassName);
         $this->config->expects($this->any())->method('getHydratedClassName')->will($this->returnValue($className));
         $this->config->expects($this->any())->method('doesAutoGenerateProxies')->will($this->returnValue(false));
+        $this
+            ->config
+            ->expects($this->any())
+            ->method('getGeneratedClassAutoloader')
+            ->will($this->returnValue($autoloader));
         $this
             ->inflector
             ->expects($this->any())
             ->method('getUserClassName')
             ->with($className)
             ->will($this->returnValue('GeneratedHydratorTestAsset\\BaseClass'));
-
         $this
             ->inflector
             ->expects($this->once())
             ->method('getGeneratedClassName')
             ->with('GeneratedHydratorTestAsset\\BaseClass')
-            ->will($this->returnValue('GeneratedHydratorTestAsset\\EmptyClass'));
+            ->will($this->returnValue($hydratorClassName));
 
         $factory        = new HydratorFactory($this->config);
         $generatedClass = $factory->getHydratorClass();
 
-        $this->assertInstanceOf('GeneratedHydratorTestAsset\\EmptyClass', new $generatedClass);
+        $this->assertInstanceOf($hydratorClassName, new $generatedClass);
     }
 
     /**


### PR DESCRIPTION
I'll be using `GeneratedHydrator` in a production environment doing "many" hydration / extract operations per second. If `autoGenerateProxies` is set to `true` (its default setting), every call to `->getHydratorClass()` will regenerate the generated hydrator class file. My intention was to pre-generate the hydrators as part of my build process and then run production with `autoGenerateProxies` set to `false`.

However, changing that setting will break the application because the generated hydrator is no longer autoloaded. Moving `$this->configuration->getGeneratedClassAutoLoader()->__invoke($hydratorClassName);` out of the conditional fixes the issue. This fix would not break BC because generated hydrators don't work with auto proxy generation turned off anyway (unless the hydrators are autoloaded manually, in which case calling the autoloader here still wouldn't break anything).

My apologies in advance if I misunderstood how this particular aspect was supposed to work. I had to dig around a bit and figure it out myself since this particular use case isn't documented.
