### PR TITLE
allow nikic/php-parser 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php":                           "~5.4",
         "zendframework/zend-stdlib":     "~2.3",
-        "nikic/php-parser":              "1.0.*",
+        "nikic/php-parser":              "~1.0",
         "ocramius/code-generator-utils": "0.3.*"
     },
     "require-dev": {


### PR DESCRIPTION
As ocramius/code-generator-utils requires 1.0... not easy to test... have to hardly remplace vendor/nikic dir..

    $ phpunit
    PHPUnit 4.7-g7b9e68d by Sebastian Bergmann and contributors.
    
    Configuration read from /work/GIT/GeneratedHydrator/phpunit.xml.dist
    
    .............................I
    
    Time: 211 ms, Memory: 11.50Mb
    
    There was 1 incomplete test:
    
    1) GeneratedHydratorTest\Functional\HydratorFunctionalTest::testDisabledMethod
    Methods have to be disabled - currently only removing them
    
    /work/GIT/GeneratedHydrator/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php:94
    
    OK, but incomplete, skipped, or risky tests!
    Tests: 30, Assertions: 84, Incomplete: 1.
