### PR TITLE
travis add php 7 + hhvm-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
+  - hhvm-nightly
 
 before_script:
   - composer self-update
@@ -21,4 +23,6 @@ after_script:
 
 matrix:
   allow_failures:
+    - php: 7
     - php: hhvm
+    - php: hhvm-nightly


### PR DESCRIPTION
and allow failure on them.

Currently the package requires php ~5.4 which conflicts, when u install it as a dependency and want to test php7 on travis
https://github.com/Ocramius/GeneratedHydrator/blob/2c29e3aaa002991609f555a6c0ecea3427825a17/composer.json#L23