### PR TITLE
Allow generated classes target dir to be null

### DIFF
--- a/src/GeneratedHydrator/Configuration.php
+++ b/src/GeneratedHydrator/Configuration.php
@@ -164,7 +164,7 @@ class Configuration
      */
     public function setGeneratedClassesTargetDir($generatedClassesTargetDir)
     {
-        $this->generatedClassesTargetDir = (string) $generatedClassesTargetDir;
+        $this->generatedClassesTargetDir = $generatedClassesTargetDir;
     }
 
     /**
@@ -176,7 +176,7 @@ class Configuration
             $this->generatedClassesTargetDir = sys_get_temp_dir();
         }
 
-        return $this->generatedClassesTargetDir;
+        return (string) $this->generatedClassesTargetDir;
     }
 
     /**


### PR DESCRIPTION
Because of the string casting, in my code I have to call `setGeneratedClassesTargetDir()` like this:

```php
class HydrateUsingGeneratedHydrator implements Hydrate
{
    /**
     * @var string|null
     */
    private $cacheDir;

    public function __construct($cacheDir)
    {
        $this->cacheDir = $cacheDir;
    }

    public function hydrate(array $data, $object)
    {
        $configuration = new Configuration(get_class($object));

        if ($this->cacheDir !== null) {
            $configuration->setGeneratedClassesTargetDir($this->cacheDir);
        }
        ...
    }
}
```

The proposed change allows me to just call `$configuration->setGeneratedClassesTargetDir($this->cacheDir);` without the extra `if` clause.