### PR TITLE
Configurable generator

### DIFF
--- a/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGenerator.php
@@ -35,7 +35,7 @@ use ReflectionClass;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class HydratorGenerator
+class HydratorGenerator implements HydratorGeneratorInterface
 {
     /**
      * Generates an AST of {@see \PhpParser\Node[]} out of a given reflection class

--- a/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactory.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactory.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace GeneratedHydrator\ClassGenerator;
+
+/**
+ * Factory for the hydrator generator
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ * @license MIT
+ */
+class HydratorGeneratorFactory implements HydratorGeneratorFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createHydratorGenerator()
+    {
+        return new HydratorGenerator;
+    }
+}

--- a/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactoryInterface.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorFactoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace GeneratedHydrator\ClassGenerator;
+
+/**
+ * Interface for the factory for the hydrator generator
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ * @license MIT
+ */
+interface HydratorGeneratorFactoryInterface
+{
+    /**
+     * Creates a HydratorGenerator
+     *
+     * @return HydratorGeneratorInterface
+     */
+    public function createHydratorGenerator();
+}

--- a/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorInterface.php
+++ b/src/GeneratedHydrator/ClassGenerator/HydratorGeneratorInterface.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace GeneratedHydrator\ClassGenerator;
+
+use ReflectionClass;
+
+/**
+ * Interface for the hydrator generator
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ * @license MIT
+ */
+interface HydratorGeneratorInterface
+{
+    /**
+     * Generates an AST of {@see \PHPParser_Node[]} out of a given reflection class
+     *
+     * @param \ReflectionClass $originalClass
+     *
+     * @return \PHPParser_Node[]
+     */
+    public function generate(ReflectionClass $originalClass);
+}

--- a/src/GeneratedHydrator/Configuration.php
+++ b/src/GeneratedHydrator/Configuration.php
@@ -19,6 +19,8 @@
 namespace GeneratedHydrator;
 
 use GeneratedHydrator\Factory\HydratorFactory;
+use GeneratedHydrator\ClassGenerator\HydratorGeneratorFactory;
+use GeneratedHydrator\ClassGenerator\HydratorGeneratorFactoryInterface;
 use CodeGenerationUtils\Autoloader\AutoloaderInterface;
 use CodeGenerationUtils\Autoloader\Autoloader;
 use CodeGenerationUtils\FileLocator\FileLocator;
@@ -71,6 +73,11 @@ class Configuration
      * @var \CodeGenerationUtils\Inflector\ClassNameInflectorInterface|null
      */
     protected $classNameInflector;
+
+    /**
+     * @var \GeneratedHydrator\ClassGenerator\Hydrator\HydratorGeneratorFactoryInterface|null
+     */
+    protected $hydratorGeneratorFactory;
 
     /**
      * @param string $hydratedClassName
@@ -219,5 +226,25 @@ class Configuration
         }
 
         return $this->classNameInflector;
+    }
+
+    /**
+     * @param \GeneratedHydrator\ClassGenerator\HydratorGeneratorFactoryInterface $hydratorGeneratorFactory
+     */
+    public function setHydratorGeneratorFactory(HydratorGeneratorFactoryInterface $hydratorGeneratorFactory)
+    {
+        $this->hydratorGeneratorFactory = $hydratorGeneratorFactory;
+    }
+
+    /**
+     * @return \GeneratedHydrator\ClassGenerator\HydratorGeneratorFactoryInterface
+     */
+    public function getHydratorGeneratorFactory()
+    {
+        if (null === $this->hydratorGeneratorFactory) {
+            $this->hydratorGeneratorFactory = new HydratorGeneratorFactory();
+        }
+
+        return $this->hydratorGeneratorFactory;
     }
 }

--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -57,10 +57,11 @@ class HydratorFactory
         $hydratorClassName = $inflector->getGeneratedClassName($realClassName, array('factory' => get_class($this)));
 
         if (! class_exists($hydratorClassName) && $this->configuration->doesAutoGenerateProxies()) {
-            $generator     = new HydratorGenerator();
-            $originalClass = new ReflectionClass($realClassName);
-            $generatedAst  = $generator->generate($originalClass);
-            $traverser     = new NodeTraverser();
+            $generatorFactory = $this->configuration->getHydratorGeneratorFactory();
+            $generator        = $generatorFactory->createHydratorGenerator();
+            $originalClass    = new ReflectionClass($realClassName);
+            $generatedAst     = $generator->generate($originalClass);
+            $traverser        = new NodeTraverser();
 
             $traverser->addVisitor(new ClassRenamerVisitor($originalClass, $hydratorClassName));
 

--- a/tests/GeneratedHydratorTest/ClassGenerator/HydratorGeneratorFactoryTest.php
+++ b/tests/GeneratedHydratorTest/ClassGenerator/HydratorGeneratorFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace GeneratedHydratorTest\ClassGenerator;
+
+use GeneratedHydrator\ClassGenerator\HydratorGeneratorFactory;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests for {@see \GeneratedHydrator\ClassGenerator\HydratorGeneratorFactory}
+ *
+ * @author Sander Marechal <s.marechal@jejik.com>
+ * @license MIT
+ *
+ * @covers \GeneratedHydrator\ClassGenerator\HydratorGeneratorFactory
+ */
+class HydratorGeneratorFactoryTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreateHydratorGenerator()
+    {
+        $factory = new HydratorGeneratorFactory();
+
+        $this->assertInstanceOf(
+            'GeneratedHydrator\\ClassGenerator\\HydratorGeneratorInterface',
+            $factory->createHydratorGenerator()
+        );
+    }
+}

--- a/tests/GeneratedHydratorTest/ConfigurationTest.php
+++ b/tests/GeneratedHydratorTest/ConfigurationTest.php
@@ -157,4 +157,21 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->configuration->setGeneratedClassAutoloader($autoloader);
         $this->assertSame($autoloader, $this->configuration->getGeneratedClassAutoloader());
     }
+
+    /**
+     * @covers \GeneratedHydrator\Configuration::getHydratorGeneratorFactory
+     * @covers \GeneratedHydrator\Configuration::setHydratorGeneratorFactory
+     */
+    public function testSetGetHydratorGeneratorFactory()
+    {
+        $this->assertInstanceOf(
+            'GeneratedHydrator\\ClassGenerator\\HydratorGeneratorFactoryInterface',
+            $this->configuration->getHydratorGeneratorFactory()
+        );
+
+        $factory = $this->getMock('GeneratedHydrator\\ClassGenerator\\HydratorGeneratorFactoryInterface');
+
+        $this->configuration->setHydratorGeneratorFactory($factory);
+        $this->assertSame($factory, $this->configuration->getHydratorGeneratorFactory());
+    }
 }

--- a/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
+++ b/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
@@ -19,6 +19,7 @@
 namespace GeneratedHydratorTest\Factory;
 
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
+use GeneratedHydrator\ClassGenerator\HydratorGenerator;
 use GeneratedHydrator\Factory\HydratorFactory;
 use PHPUnit_Framework_TestCase;
 
@@ -104,15 +105,22 @@ class HydratorFactoryTest extends PHPUnit_Framework_TestCase
         $generatedClassName = UniqueIdentifierGenerator::getIdentifier('bar');
         $generator      = $this->getMock('CodeGenerationUtils\\GeneratorStrategy\\GeneratorStrategyInterface');
         $autoloader     = $this->getMock('CodeGenerationUtils\\Autoloader\\AutoloaderInterface');
+        $hydratorGeneratorFactory = $this->getMock('GeneratedHydrator\\ClassGenerator\\HydratorGeneratorFactoryInterface');
 
         $this->config->expects($this->any())->method('getHydratedClassName')->will($this->returnValue($className));
         $this->config->expects($this->any())->method('doesAutoGenerateProxies')->will($this->returnValue(true));
         $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
+        $this->config->expects($this->any())->method('getHydratorGeneratorFactory')->will($this->returnValue($hydratorGeneratorFactory));
         $this
             ->config
             ->expects($this->any())
             ->method('getGeneratedClassAutoloader')
             ->will($this->returnValue($autoloader));
+
+        $hydratorGeneratorFactory
+            ->expects($this->once())
+            ->method('createHydratorGenerator')
+            ->will($this->returnValue(new HydratorGenerator()));
 
         $generator
             ->expects($this->once())


### PR DESCRIPTION
This is a rebase of #21 with added unittests.

One thing I am wondering about is the method signature of `HydratorGeneratorFactory::createHydratorGenerator()`. The original implementation by @magnusnordlander has no parameters for this method. I think it may be smart to pass `$realClassName` as a parameter so that a factory can return different types of HydratorGenerators for different classes.