### PR TITLE
Configurable generator using custom node visitors

### DIFF
--- a/src/GeneratedHydrator/Configuration.php
+++ b/src/GeneratedHydrator/Configuration.php
@@ -73,6 +73,11 @@ class Configuration
     protected $classNameInflector;
 
     /**
+     * @var \PhpParser\NodeVisitor[]
+     */
+    protected $customVisitors = [];
+
+    /**
      * @param string $hydratedClassName
      */
     public function __construct($hydratedClassName)
@@ -219,5 +224,21 @@ class Configuration
         }
 
         return $this->classNameInflector;
+    }
+
+    /**
+     * @param \PhpParser\NodeVisitor[] $visitors
+     */
+    public function setCustomVisitors(array $customVisitors)
+    {
+        $this->customVisitors = $customVisitors;
+    }
+
+    /**
+     * @return \PhpParser\NodeVisitor[]
+     */
+    public function getCustomVisitors()
+    {
+        return $this->customVisitors;
     }
 }

--- a/src/GeneratedHydrator/Configuration.php
+++ b/src/GeneratedHydrator/Configuration.php
@@ -26,6 +26,7 @@ use CodeGenerationUtils\GeneratorStrategy\FileWriterGeneratorStrategy;
 use CodeGenerationUtils\GeneratorStrategy\GeneratorStrategyInterface;
 use CodeGenerationUtils\Inflector\ClassNameInflectorInterface;
 use CodeGenerationUtils\Inflector\ClassNameInflector;
+use PhpParser\NodeVisitor;
 
 /**
  * Base configuration class for the generated hydrator - serves as micro disposable DIC/facade
@@ -231,6 +232,12 @@ class Configuration
      */
     public function setCustomVisitors(array $customVisitors)
     {
+        foreach ($customVisitors as $visitor) {
+            if (!($visitor instanceof NodeVisitor)) {
+                throw new \InvalidArgumentException('Custom visitor must implement \\PhpParser\\NodeVisitor');
+            }
+        }
+
         $this->customVisitors = $customVisitors;
     }
 

--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -64,6 +64,10 @@ class HydratorFactory
 
             $traverser->addVisitor(new ClassRenamerVisitor($originalClass, $hydratorClassName));
 
+            foreach ($this->configuration->getCustomVisitors() as $visitor) {
+                $traverser->addVisitor($visitor);
+            }
+
             $this->configuration->getGeneratorStrategy()->generate($traverser->traverse($generatedAst));
             $this->configuration->getGeneratedClassAutoloader()->__invoke($hydratorClassName);
         }

--- a/tests/GeneratedHydratorTest/ConfigurationTest.php
+++ b/tests/GeneratedHydratorTest/ConfigurationTest.php
@@ -157,4 +157,27 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->configuration->setGeneratedClassAutoloader($autoloader);
         $this->assertSame($autoloader, $this->configuration->getGeneratedClassAutoloader());
     }
+
+    /**
+     * @covers \GeneratedHydrator\Configuration::getCustomVisitors
+     * @covers \GeneratedHydrator\Configuration::setCustomVisitors
+     */
+    public function testSetGetCustomVisitors()
+    {
+        $this->assertCount(0, $this->configuration->getCustomVisitors());
+
+        $visitors = [$this->getMock('PhpParser\NodeVisitor')];
+
+        $this->configuration->setCustomVisitors($visitors);
+        $this->assertSame($visitors, $this->configuration->getCustomVisitors());
+    }
+
+    /**
+     * @covers \GeneratedHydrator\Configuration::setCustomVisitors
+     * @expectedException InvalidArgumentException
+     */
+    public function testSetInvalidCustomVisitor()
+    {
+        $this->configuration->setCustomVisitors([new \StdClass()]);
+    }
 }

--- a/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
+++ b/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
@@ -108,6 +108,7 @@ class HydratorFactoryTest extends PHPUnit_Framework_TestCase
         $this->config->expects($this->any())->method('getHydratedClassName')->will($this->returnValue($className));
         $this->config->expects($this->any())->method('doesAutoGenerateProxies')->will($this->returnValue(true));
         $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
+        $this->config->expects($this->any())->method('getCustomVisitors')->will($this->returnValue([]));
         $this
             ->config
             ->expects($this->any())


### PR DESCRIPTION
This PR is a possible alternative to #39. It allows customizing the generated hydrators by setting custom node visitors in the configuration.

As an extension to this, perhaps even the built-in HydratorMethodsVisitor could be made configurable in this way? That would allow a user to replace the HydratorMethodsVisitor with his own implementation.