### PR TITLE
Prevent warning when class_exists is called

### DIFF
--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -60,7 +60,7 @@ class HydratorFactory
         $realClassName     = $inflector->getUserClassName($this->configuration->getHydratedClassName());
         $hydratorClassName = $inflector->getGeneratedClassName($realClassName, array('factory' => get_class($this)));
 
-        if (! class_exists($hydratorClassName) && $this->configuration->doesAutoGenerateProxies()) {
+        if (! @class_exists($hydratorClassName) && $this->configuration->doesAutoGenerateProxies()) {
             $generator     = $this->configuration->getHydratorGenerator();
             $originalClass = new ReflectionClass($realClassName);
             $generatedAst   = $generator->generate($originalClass);


### PR DESCRIPTION
When `classmap` parameter is used in `composer.json` and file hasn't been generated yet, it throws a warning when calling `class_exists` because it tries to include the non-yet-existing file.

So unless I use a different autoloader when generating the cache files, the error shows up for the first generation.

This PR wants to fix that by silencing the warning.