### PR TITLE
Fix phpunit deprecated methods

### DIFF
--- a/tests/GeneratedHydratorTest/ConfigurationTest.php
+++ b/tests/GeneratedHydratorTest/ConfigurationTest.php
@@ -109,7 +109,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         self::assertInstanceOf(ClassNameInflectorInterface::class, $this->configuration->getClassNameInflector());
 
         /* @var $inflector ClassNameInflectorInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $inflector = $this->getMock(ClassNameInflectorInterface::class);
+        $inflector = $this->createMock(ClassNameInflectorInterface::class);
 
         $this->configuration->setClassNameInflector($inflector);
         self::assertSame($inflector, $this->configuration->getClassNameInflector());
@@ -125,7 +125,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         self::assertInstanceOf(GeneratorStrategyInterface::class, $this->configuration->getGeneratorStrategy());
 
         /* @var $strategy GeneratorStrategyInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $strategy = $this->getMock(GeneratorStrategyInterface::class);
+        $strategy = $this->createMock(GeneratorStrategyInterface::class);
 
         $this->configuration->setGeneratorStrategy($strategy);
         self::assertSame($strategy, $this->configuration->getGeneratorStrategy());
@@ -152,7 +152,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         self::assertInstanceOf(AutoloaderInterface::class, $this->configuration->getGeneratedClassAutoloader());
 
         /* @var $autoloader AutoloaderInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $autoloader = $this->getMock(AutoloaderInterface::class);
+        $autoloader = $this->createMock(AutoloaderInterface::class);
 
         $this->configuration->setGeneratedClassAutoloader($autoloader);
         self::assertSame($autoloader, $this->configuration->getGeneratedClassAutoloader());
@@ -167,7 +167,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         self::assertInstanceOf(HydratorGeneratorInterface::class, $this->configuration->getHydratorGenerator());
 
         /* @var $generator HydratorGeneratorInterface */
-        $generator = $this->getMock(HydratorGeneratorInterface::class);
+        $generator = $this->createMock(HydratorGeneratorInterface::class);
 
         $this->configuration->setHydratorGenerator($generator);
         self::assertSame($generator, $this->configuration->getHydratorGenerator());

--- a/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
+++ b/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
@@ -50,7 +50,7 @@ class HydratorFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->inflector = $this->getMock('CodeGenerationUtils\\Inflector\\ClassNameInflectorInterface');
+        $this->inflector = $this->createMock(ClassNameInflectorInterface::class);
         $this->config    = $this
             ->getMockBuilder('GeneratedHydrator\\Configuration')
             ->disableOriginalConstructor()
@@ -107,8 +107,8 @@ class HydratorFactoryTest extends PHPUnit_Framework_TestCase
     {
         $className          = UniqueIdentifierGenerator::getIdentifier('foo');
         $generatedClassName = UniqueIdentifierGenerator::getIdentifier('bar');
-        $generator          = $this->getMock(GeneratorStrategyInterface::class);
-        $autoloader         = $this->getMock(AutoloaderInterface::class);
+        $generator          = $this->createMock(GeneratorStrategyInterface::class);
+        $autoloader         = $this->createMock(AutoloaderInterface::class);
 
         $this->config->expects(self::any())->method('getHydratedClassName')->will(self::returnValue($className));
         $this->config->expects(self::any())->method('doesAutoGenerateProxies')->will(self::returnValue(true));

--- a/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
+++ b/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
@@ -22,6 +22,7 @@ namespace GeneratedHydratorTest\Factory;
 
 use CodeGenerationUtils\Autoloader\AutoloaderInterface;
 use CodeGenerationUtils\GeneratorStrategy\GeneratorStrategyInterface;
+use CodeGenerationUtils\Inflector\ClassNameInflectorInterface;
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 use GeneratedHydrator\ClassGenerator\HydratorGenerator;
 use GeneratedHydrator\Factory\HydratorFactory;

--- a/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
@@ -100,7 +100,7 @@ class HydratorFunctionalTest extends PHPUnit_Framework_TestCase
 
         $generatedClass = $this->generateHydrator(new HydratedObject());
 
-        $this->setExpectedException(DisabledMethodException::class);
+        $this->expectException(DisabledMethodException::class);
         $generatedClass->doFoo();
     }
 
@@ -135,7 +135,7 @@ class HydratorFunctionalTest extends PHPUnit_Framework_TestCase
         $generatedClassName = __NAMESPACE__ . '\\' . UniqueIdentifierGenerator::getIdentifier('Foo');
         $config             = new Configuration($parentClassName);
         /* @var $inflector ClassNameInflectorInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $inflector          = $this->getMock(ClassNameInflectorInterface::class);
+        $inflector          = $this->createMock(ClassNameInflectorInterface::class);
 
         $inflector
             ->expects(self::any())


### PR DESCRIPTION
`getMock` is replaced with `createMock` and `setExpectedException` can be replaced with `expectException`