### PR TITLE
chore: use php-parser v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: php
 
 php:
   - 7.0
+  - 7.1
   - hhvm
+  - nightly
 
 env:
   matrix:
@@ -12,6 +14,7 @@ env:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly
 
 before_script:
   - if [ "$DEPENDENCIES" = "high" ]; then composer --prefer-source update; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,18 @@ php:
   - 7.0
   - hhvm
 
+env:
+  matrix:
+    - DEPENDENCIES="high"
+    - DEPENDENCIES="low"
+
 matrix:
   allow_failures:
     - php: hhvm
 
 before_script:
-  - composer self-update
-  - composer update --prefer-source --dev
+  - if [ "$DEPENDENCIES" = "high" ]; then composer --prefer-source update; fi;
+  - if [ "$DEPENDENCIES" = "low" ]; then composer --prefer-lowest --prefer-source update; fi;
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml --exclude-group Functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ script:
   - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml --exclude-group Functional
   - ./vendor/bin/phpunit --group=Functional
   - php -n ./vendor/bin/phpbench run --report=aggregate --revs=500 --iterations=50 --warmup=3
-  - ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/ ./benchmarks
+  # Only run the code standards with the latest package
+  - if [ "$DEPENDENCIES" = "high" ]; then ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/ ./benchmarks; fi;
 
 after_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.0' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit":           "^5.7.21",
-        "squizlabs/php_codesniffer": "~2.0",
+        "squizlabs/php_codesniffer": "^3.0",
         "phpbench/phpbench":         "^0.13.0",
         "zendframework/zend-filter": "^2.7",
         "zendframework/zend-servicemanager": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php":                           "~7.0",
-        "nikic/php-parser":              "~2.0",
-        "ocramius/code-generator-utils": "0.4.*",
+        "nikic/php-parser":              "~2.0|~3.0",
+        "ocramius/code-generator-utils": "~0.4",
         "zendframework/zend-hydrator":   "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zendframework/zend-hydrator":   "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit":           "~5.0",
+        "phpunit/phpunit":           "^5.7.21",
         "squizlabs/php_codesniffer": "~2.0",
         "phpbench/phpbench":         "^0.13.0",
         "zendframework/zend-filter": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "squizlabs/php_codesniffer": "~2.0",
         "phpbench/phpbench":         "^0.13.0",
         "zendframework/zend-filter": "^2.7",
-        "zendframework/zend-servicemanager": "^3.2"
+        "zendframework/zend-servicemanager": "^3.2",
+        "zendframework/zend-stdlib": "^3.1"
     },
     "autoload": {
         "psr-0": {

--- a/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
+++ b/tests/GeneratedHydratorTest/Factory/HydratorFactoryTest.php
@@ -137,24 +137,24 @@ class HydratorFactoryTest extends PHPUnit_Framework_TestCase
                 return true;
             });
 
-        $this
+            $this
             ->inflector
             ->expects(self::once())
             ->method('getGeneratedClassName')
             ->with('GeneratedHydratorTestAsset\\BaseClass')
             ->will(self::returnValue($generatedClassName));
 
-        $this
+            $this
             ->inflector
             ->expects(self::once())
             ->method('getUserClassName')
             ->with($className)
             ->will(self::returnValue('GeneratedHydratorTestAsset\\BaseClass'));
 
-        $factory        = new HydratorFactory($this->config);
+            $factory        = new HydratorFactory($this->config);
         /* @var $generatedClass \GeneratedHydratorTestAsset\LazyLoadingMock */
-        $generatedClass = $factory->getHydratorClass();
+            $generatedClass = $factory->getHydratorClass();
 
-        self::assertInstanceOf($generatedClassName, new $generatedClass);
+            self::assertInstanceOf($generatedClassName, new $generatedClass);
     }
 }


### PR DESCRIPTION
Hi,

This uses my forked version of CodeGenerationUtils which supports PHP parser v3 (PR for that). The tests are passing, the very simple app I have continues to work but its very possible its not 100% BC.

Would you prefer to keep support for both `2.0|3.0`? If so I should likely edit the Travis to do a matrix like for --prefer-lowest etc.

Solves https://github.com/Ocramius/GeneratedHydrator/issues/67

Will rebase once the dependencies are sorted/tagged