### PR TITLE
#68 - fix NULL hydration

### DIFF
--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -133,7 +133,8 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
             // Hydrate closures
             $bodyParts[] = "\$this->hydrateCallbacks[] = \\Closure::bind(function (\$object, \$values) {";
             foreach ($propertyNames as $propertyName) {
-                $bodyParts[] = "    if (isset(\$values['" . $propertyName . "'])) {";
+                $bodyParts[] = "    if (isset(\$values['" . $propertyName . "']) || ".
+                "\$object->" . $propertyName . " !== null && \\array_key_exists('" . $propertyName . "', \$values)) {";
                 $bodyParts[] = "        \$object->" . $propertyName . " = \$values['" . $propertyName . "'];";
                 $bodyParts[] = "    }";
             }
@@ -164,7 +165,8 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
 
         $bodyParts = array();
         foreach ($this->visiblePropertyMap as $propertyName) {
-            $bodyParts[] = "if (isset(\$data['" . $propertyName . "'])) {";
+            $bodyParts[] = "if (isset(\$data['" . $propertyName . "']) || ".
+            "\$object->" . $propertyName . " !== null && \\array_key_exists('" . $propertyName . "', \$data)) {";
             $bodyParts[] = "    \$object->" . $propertyName . " = \$data['" . $propertyName . "'];";
             $bodyParts[] = "}";
         }

--- a/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
@@ -84,6 +84,17 @@ class HydratorFunctionalTest extends PHPUnit_Framework_TestCase
         self::assertSame($inspectionData, $extracted);
     }
 
+    public function testHydratingNull()
+    {
+        $instance = new ClassWithPrivateProperties();
+
+        self::assertSame('property0', $instance->getProperty0());
+
+        $this->generateHydrator($instance)->hydrate(['property0' => null], $instance);
+
+        self::assertSame(null, $instance->getProperty0());
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
```php
if (isset($values['property'] || $object->property !== null && array_key_exists('property', $values)) {
    $object->property = $values['property'];
}
```
is a lot more efficient than
```php
isset($values['property'] || array_key_exists('property', $values) {
    $object->property = $values['property'];
}
```

Especially in real word cases, because classes usually don't have default value specified, so array_key_exists will never trigger in such cases (no need to write null if property is already null).