### PR TITLE
Possible performance boost

### DIFF
--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -115,7 +115,7 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
         // then be called in order in the hydrate() and extract() methods.
         foreach ($this->hiddenPropertyMap as $className => $propertyNames) {
             // Hydrate closures
-            $bodyParts[] = "\$this->hydrateCallbacks[] = \\Closure::bind(function (\$object, \$values) {";
+            $bodyParts[] = "\$this->hydrateCallbacks[] = \\Closure::bind(function (\$object, &\$values) {";
             foreach ($propertyNames as $propertyName) {
                 $bodyParts[] = "    if (isset(\$values['" . $propertyName . "']) || ".
                 '$object->' . $propertyName . " !== null && \\array_key_exists('" . $propertyName . "', \$values)) {";


### PR DESCRIPTION
Spotted this while reading the generated code; hoping that your test suite will validate this hypothesis for me:

Passing values by reference here may prevent an in memory copy of the array and improve performance.

(PHP 7 possibly already does this optimisation for values which aren't written to?)