### PR TITLE
Add getHydrator method to the HydratorFactory

### DIFF
--- a/src/GeneratedHydrator/Factory/HydratorFactory.php
+++ b/src/GeneratedHydrator/Factory/HydratorFactory.php
@@ -9,6 +9,7 @@ use CodeGenerationUtils\Visitor\ClassRenamerVisitor;
 use GeneratedHydrator\Configuration;
 use PhpParser\NodeTraverser;
 use ReflectionClass;
+use Zend\Hydrator\HydratorInterface;
 use function class_exists;
 
 /**
@@ -48,5 +49,17 @@ class HydratorFactory
         }
 
         return $hydratorClassName;
+    }
+
+    /**
+     * Instantiates the generated hydrator class
+     *
+     * @return HydratorInterface
+     * @throws InvalidGeneratedClassesDirectoryException
+     */
+    public function getHydrator(): HydratorInterface
+    {
+        $hydratorClass = $this->getHydratorClass();
+        return new $hydratorClass();
     }
 }

--- a/tests/GeneratedHydratorTest/Factory/HydratorFactoryFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Factory/HydratorFactoryFunctionalTest.php
@@ -59,4 +59,17 @@ class HydratorFactoryFunctionalTest extends TestCase
 
         self::assertInstanceOf('Zend\Hydrator\HydratorInterface', new $generatedClass());
     }
+
+    /**
+     * @covers \GeneratedHydrator\Factory\HydratorFactory::__construct
+     * @covers \GeneratedHydrator\Factory\HydratorFactory::getHydrator
+     */
+    public function testWillInstantiateValidHydrator(): void
+    {
+        $factory = $this->config->createFactory();
+        $hydratorClass = $factory->getHydratorClass();
+        $hydrator = $factory->getHydrator();
+
+        self::assertEquals(new $hydratorClass(), $hydrator);
+    }
 }


### PR DESCRIPTION
Fix issue #26

Now it is possible to use the HydratorFactory as a real factory:

````php
<?php

use GeneratedHydrator\Configuration;

require_once __DIR__ . '/vendor/autoload.php';

class Example
{
    public    $foo = 1;
    protected $bar = 2;
    protected $baz = 3;
}

$config        = new Configuration('Example');
$hydrator = $config->createFactory()->getHydrator();

var_dump($hydrator->extract($object)); // ['foo' => 1, 'bar' => 2, 'baz' => 3]
$hydrator->hydrate(
    ['foo' => 4, 'bar' => 5, 'baz' => 6],
    $object
);
var_dump($hydrator->extract($object)); // ['foo' => 4, 'bar' => 5, 'baz' => 6]
````