### PR TITLE
issue #118: skip uninitialized typed properties without default value in extract

### DIFF
--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -140,20 +140,20 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
             $bodyParts[] = '$this->extractCallbacks[] = \\Closure::bind(static function ($object, &$values) {';
             foreach ($properties as $property) {
                 $propertyName = $property->name;
-                if ($property->hasType && !$property->hasDefault) {
+                if ($property->hasType && ! $property->hasDefault) {
                     $escapedName = var_export($propertyName, true);
 
-                    $bodyParts[]  = 'static $pref;';
-                    $bodyParts[]  = 'if ($pref === null) {';
+                    $bodyParts[] = 'static $pref;';
+                    $bodyParts[] = 'if ($pref === null) {';
                     $bodyParts[] = '    $pref = new \ReflectionProperty($object, ' . $escapedName . ');';
                     $bodyParts[] = '    $pref->setAccessible(true);';
-                    $bodyParts[]  = '}';
+                    $bodyParts[] = '}';
 
-                    $bodyParts[]  = 'if (isset($object->' . $propertyName . ') || $pref->isInitialized($object)) {';
-                    $bodyParts[]  = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
-                    $bodyParts[]  = '}';
+                    $bodyParts[] = 'if (isset($object->' . $propertyName . ') || $pref->isInitialized($object)) {';
+                    $bodyParts[] = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
+                    $bodyParts[] = '}';
                 } else {
-                    $bodyParts[]  = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
+                    $bodyParts[] = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
                 }
             }
             $bodyParts[] = '}, null, ' . var_export($className, true) . ');' . "\n";

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -149,7 +149,7 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
                     $bodyParts[] = '    $pref->setAccessible(true);';
                     $bodyParts[]  = '}';
 
-                    $bodyParts[]  = 'if ($pref->isInitialized($object)) {';
+                    $bodyParts[]  = 'if (isset($object->' . $propertyName . ') || $pref->isInitialized($object)) {';
                     $bodyParts[]  = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
                     $bodyParts[]  = '}';
                 } else {

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -140,7 +140,21 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
             $bodyParts[] = '$this->extractCallbacks[] = \\Closure::bind(static function ($object, &$values) {';
             foreach ($properties as $property) {
                 $propertyName = $property->name;
-                $bodyParts[]  = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
+                if ($property->hasType && !$property->hasDefault) {
+                    $escapedName = var_export($propertyName, true);
+
+                    $bodyParts[]  = 'static $pref;';
+                    $bodyParts[]  = 'if ($pref === null) {';
+                    $bodyParts[] = '    $pref = new \ReflectionProperty($object, ' . $escapedName . ');';
+                    $bodyParts[] = '    $pref->setAccessible(true);';
+                    $bodyParts[]  = '}';
+
+                    $bodyParts[]  = 'if ($pref->isInitialized($object)) {';
+                    $bodyParts[]  = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
+                    $bodyParts[]  = '}';
+                } else {
+                    $bodyParts[]  = "    \$values['" . $propertyName . "'] = \$object->" . $propertyName . ';';
+                }
             }
             $bodyParts[] = '}, null, ' . var_export($className, true) . ');' . "\n";
         }

--- a/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
@@ -127,6 +127,27 @@ class HydratorFunctionalTest extends TestCase
     }
 
     /**
+     * @requires PHP >= 7.4
+     */
+    public function testExtractSkipsNonSetValues() : void
+    {
+        $instance = new ClassWithTypedProperties();
+        $hydrator = $this->generateHydrator($instance);
+
+        $reference =  $hydrator->extract($instance);
+
+        self::assertSame([
+            'property0' => 1,
+            'property1' => 2,
+            // $property2 skipped as it does not exists
+            // $property3 skipped as it does not exists
+            'property4' => null,
+            'untyped0' => null, // 'untyped0' is null by default
+            'untyped1' => null, // 'untyped1' is null by default
+        ], $reference);
+    }
+
+    /**
      * @return mixed[]
      */
     public function getHydratorClasses() : array


### PR DESCRIPTION
Hi, currently the `extract` method fails when attempts to read uninitialized properties. This is non-intuitive behavior. It also contradicts the behavior of embedded functions like `print_r`, `var_dump`, `var_export` which either skip or highlight function.

The current approach makes impossible to declare auto-incremental properties in models without giving them default value (which they can't have).

I've initially used `property_exists` but I failed as for some reason it triggers the same error (not sure why it needs to access the value).

This PR contains:
- test of extract method for uninitialized typed properties without default
- reflection-based extract callback (yes, I know...)

Notes:
I'm not super proud of this PR as it uses reflection and `static` to speed it up. This PR should not affect the performance of any property unless it's typed and has no default value.

Example of generated code:

```php
$this->extractCallbacks[] = \Closure::bind(static function ($object, &$values) {
    static $pref;
    if ($pref === null) {
        $pref = new \ReflectionProperty($object, 'id');
        $pref->setAccessible(true);
    }
    if ($pref->isInitialized($object)) {
        $values['id'] = $object->id;
    }
}, null, 'Product');
```