### PR TITLE
Implement GeneratedHydrators with AbstractHydrator as base class

### DIFF
--- a/src/GeneratedHydrator/ClassGenerator/AbstractHydratorGenerator.php
+++ b/src/GeneratedHydrator/ClassGenerator/AbstractHydratorGenerator.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydrator\ClassGenerator;
+
+use CodeGenerationUtils\Visitor\ClassExtensionVisitor;
+use GeneratedHydrator\CodeGenerator\Visitor\AbstractHydratorMethodsVisitor;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeTraverser;
+use ReflectionClass;
+use Zend\Hydrator\AbstractHydrator;
+use function explode;
+
+/**
+ * Generator for highly performing {@see \Zend\Hydrator\HydratorInterface}
+ * for objects
+ *
+ * {@inheritDoc}
+ */
+class AbstractHydratorGenerator implements HydratorGenerator
+{
+    /**
+     * Generates an AST of {@see \PhpParser\Node[]} out of a given reflection class
+     * and a map of properties to be used to
+     *
+     * @return Node[]
+     */
+    public function generate(ReflectionClass $originalClass): array
+    {
+        $ast = [new Class_($originalClass->getShortName())];
+
+        $namespace = $originalClass->getNamespaceName();
+        if ($namespace) {
+            $ast = [new Namespace_(new Name(explode('\\', $namespace)), $ast)];
+        }
+
+        $implementor = new NodeTraverser();
+        $implementor->addVisitor(new AbstractHydratorMethodsVisitor($originalClass));
+        $implementor->addVisitor(new ClassExtensionVisitor($originalClass->getName(), AbstractHydrator::class));
+
+        return $implementor->traverse($ast);
+    }
+}

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/AbstractHydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/AbstractHydratorMethodsVisitor.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydrator\CodeGenerator\Visitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use ReflectionClass;
+use ReflectionProperty;
+use function array_filter;
+use function array_merge;
+use function implode;
+use function reset;
+use function var_export;
+
+/**
+ * Replaces methods `__construct`, `hydrate` and `extract` in the classes of the given AST
+ *
+ * @todo as per https://github.com/Ocramius/GeneratedHydrator/pull/59, using a visitor for this is ineffective.
+ * @todo Instead, we can just create a code generator, since we are not modifying code, but creating it.
+ */
+class AbstractHydratorMethodsVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var ObjectProperty[]
+     * @psalm-var list<ObjectProperty>
+     */
+    private $visiblePropertyMap = [];
+
+    /**
+     * @var array<string, ObjectProperty[]>
+     * @psalm-var array<string, list<ObjectProperty>>
+     */
+    private $hiddenPropertyMap = [];
+
+    public function __construct(ReflectionClass $reflectedClass)
+    {
+        foreach ($this->findAllInstanceProperties($reflectedClass) as $property) {
+            $className = $property->getDeclaringClass()->getName();
+
+            if ($property->isPrivate() || $property->isProtected()) {
+                $this->hiddenPropertyMap[$className][] = ObjectProperty::fromReflection($property);
+            } else {
+                $this->visiblePropertyMap[] = ObjectProperty::fromReflection($property);
+            }
+        }
+    }
+
+    public function leaveNode(Node $node): ?Class_
+    {
+        if (!$node instanceof Class_) {
+            return null;
+        }
+
+        $node->stmts[] = new Property(Class_::MODIFIER_PRIVATE, [
+            new PropertyProperty('hydrateCallbacks', new Array_()),
+            new PropertyProperty('extractCallbacks', new Array_()),
+        ]);
+
+        $this->replaceConstructor($this->findOrCreateMethod($node, '__construct'));
+        $this->replaceHydrate($this->findOrCreateMethod($node, 'hydrate'));
+        $this->replaceExtract($this->findOrCreateMethod($node, 'extract'));
+
+        return $node;
+    }
+
+    /**
+     * Find all class properties recursively using class hierarchy without
+     * removing name redefinitions
+     *
+     * @return ReflectionProperty[]
+     */
+    private function findAllInstanceProperties(?ReflectionClass $class = null): array
+    {
+        if (!$class) {
+            return [];
+        }
+
+        return array_values(array_merge(
+            $this->findAllInstanceProperties($class->getParentClass() ?: null), // of course PHP is shit.
+            array_values(array_filter(
+                $class->getProperties(),
+                static function (ReflectionProperty $property): bool {
+                    return !$property->isStatic();
+                }
+            ))
+        ));
+    }
+
+    private function generateExtractValueCall(ObjectProperty $property, string $inputArrayName): array
+    {
+        $propertyName = $property->name;
+        $escapedName  = var_export($propertyName, true);
+
+        if ($property->allowsNull && ! $property->hasDefault) {
+            return ['$object->' . $propertyName . ' = $that->extractValue(' . $escapedName . ', ' . $inputArrayName . '[' . $escapedName . '] ?? null, $object) ?? null;'];
+        }
+
+        return [
+            'if (isset(' . $inputArrayName . '[' . $escapedName . '])',
+            '    || $object->' . $propertyName . ' !== null && \\array_key_exists(' . $escapedName . ', ' . $inputArrayName . ')',
+            ') {',
+            '    $object->' . $propertyName . ' = $that->extractValue(' . $escapedName . ', ' . $inputArrayName . '[' . $escapedName . '], $object);',
+            '}',
+        ];
+    }
+
+    private function generateHydrateValueCall(ObjectProperty $property, string $inputArrayName): array
+    {
+        $propertyName = $property->name;
+        $escapedName  = var_export($propertyName, true);
+
+        if ($property->allowsNull && ! $property->hasDefault) {
+            return ['$object->' . $propertyName . ' = $this->hydrateValue(' . $escapedName . ', ' . $inputArrayName . '[' . $escapedName . '] ?? null, $object) ?? null;'];
+        }
+
+        return [
+            'if (isset(' . $inputArrayName . '[' . $escapedName . '])',
+            '    || $object->' . $propertyName . ' !== null && \\array_key_exists(' . $escapedName . ', ' . $inputArrayName . ')',
+            ') {',
+            '    $object->' . $propertyName . ' = $this->hydrateValue(' . $escapedName . ', ' . $inputArrayName . '[' . $escapedName . '], $object);',
+            '}',
+        ];
+    }
+
+    private function replaceConstructor(ClassMethod $method): void
+    {
+        $method->params = [];
+        $bodyParts = ['parent::__construct();'];
+
+        // Create a set of closures that will be called to hydrate the object.
+        // Array of closures in a naturally indexed array, ordered, which will
+        // then be called in order in the hydrate() and extract() methods.
+        foreach ($this->hiddenPropertyMap as $className => $properties) {
+            // Hydrate closures
+            $bodyParts[] = '$this->hydrateCallbacks[] = \\Closure::bind(static function ($object, $values, $that) {';
+            foreach ($properties as $property) {
+                $bodyParts = array_merge($bodyParts, $this->generateExtractValueCall($property, '$values'));
+            }
+            $bodyParts[] = '}, null, ' . var_export($className, true) . ');' . "\n";
+
+            // Extract closures
+            $bodyParts[] = '$this->extractCallbacks[] = \\Closure::bind(static function ($object, &$values, $that) {';
+            foreach ($properties as $property) {
+                $propertyName = $property->name;
+                $bodyParts[] = "    \$values['" . $propertyName . "'] = \$that->extractValue('" . $propertyName . "', \$object->" . $propertyName . ', $object);';
+            }
+            $bodyParts[] = '}, null, ' . var_export($className, true) . ');' . "\n";
+        }
+
+        $method->stmts = (new ParserFactory())
+            ->create(ParserFactory::ONLY_PHP7)
+            ->parse('<?php ' . implode("\n", $bodyParts));
+    }
+
+    private function replaceHydrate(ClassMethod $method): void
+    {
+        $method->params = [
+            new Param(new Node\Expr\Variable('data'), null, 'array'),
+            new Param(new Node\Expr\Variable('object')),
+        ];
+
+        $bodyParts = [];
+        foreach ($this->visiblePropertyMap as $property) {
+            $bodyParts = array_merge($bodyParts, $this->generateHydrateValueCall($property, '$data'));
+        }
+        $index = 0;
+        foreach ($this->hiddenPropertyMap as $className => $propertyNames) {
+            $bodyParts[] = '$this->hydrateCallbacks[' . ($index++) . ']->__invoke($object, $data, $this);';
+        }
+
+        $bodyParts[] = 'return $object;';
+
+        $method->stmts = (new ParserFactory())
+            ->create(ParserFactory::ONLY_PHP7)
+            ->parse('<?php ' . implode("\n", $bodyParts));
+    }
+
+    private function replaceExtract(ClassMethod $method): void
+    {
+        $method->params = [new Param(new Node\Expr\Variable('object'))];
+
+        $bodyParts   = [];
+        $bodyParts[] = '$ret = array();';
+        foreach ($this->visiblePropertyMap as $property) {
+            $propertyName = $property->name;
+            $bodyParts[] = "\$ret['" . $propertyName . "'] = \$this->extractValue('" . $propertyName . "', \$object->" . $propertyName . ', $object);';
+        }
+        $index = 0;
+        foreach ($this->hiddenPropertyMap as $className => $propertyNames) {
+            $bodyParts[] = '$this->extractCallbacks[' . ($index++) . ']->__invoke($object, $ret, $this);';
+        }
+
+        $bodyParts[] = 'return $ret;';
+
+        $method->stmts = (new ParserFactory())
+            ->create(ParserFactory::ONLY_PHP7)
+            ->parse('<?php ' . implode("\n", $bodyParts));
+    }
+
+    /**
+     * Finds or creates a class method (and eventually attaches it to the class itself)
+     *
+     * @deprecated not needed if we move away from code replacement
+     */
+    private function findOrCreateMethod(Class_ $class, string $name): ClassMethod
+    {
+        $foundMethods = array_filter(
+            $class->getMethods(),
+            static function (ClassMethod $method) use ($name): bool {
+                return $name === (string) $method->name;
+            }
+        );
+
+        $method = reset($foundMethods);
+
+        if (!$method) {
+            $class->stmts[] = $method = new ClassMethod($name);
+        }
+
+        return $method;
+    }
+}

--- a/src/GeneratedHydrator/Strategy/RecursiveHydrationStrategy.php
+++ b/src/GeneratedHydrator/Strategy/RecursiveHydrationStrategy.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydrator\Strategy;
+
+use Zend\Hydrator\HydratorInterface;
+use Zend\Hydrator\Strategy\StrategyInterface;
+
+class RecursiveHydrationStrategy implements StrategyInterface
+{
+    /**
+     * @var HydratorInterface
+     */
+    private HydratorInterface $hydrator;
+
+    /**
+     * @var string
+     */
+    private string $className;
+
+    /**
+     * @var bool
+     */
+    private bool $isCollection;
+
+    public function __construct(HydratorInterface $hydrator, string $className, bool $isCollection = false)
+    {
+        $this->hydrator = $hydrator;
+        $this->className = $className;
+        $this->isCollection = $isCollection;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array|mixed
+     */
+    public function extract($value)
+    {
+        if (!$this->isCollection) {
+            return $this->extractObject($value);
+        }
+
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+
+        $collection = [];
+
+        foreach ($value as $item) {
+            $collection[] = $this->extractObject($item);
+        }
+
+        return $collection;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed|object
+     */
+    public function hydrate($value)
+    {
+        if (!$this->isCollection) {
+            return $this->hydrateObject($value);
+        }
+
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+
+        $collection = [];
+
+        foreach ($value as $item) {
+            $collection[] = $this->hydrateObject($item);
+        }
+
+        return $collection;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array|mixed
+     */
+    private function extractObject($value)
+    {
+        if (!$value instanceof $this->className) {
+            throw new \InvalidArgumentException('The $value is not an instance of "' . $this->className . '".');
+        }
+
+        return $this->hydrator->extract($value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return object|mixed
+     */
+    private function hydrateObject($value)
+    {
+        $instance = new $this->className();
+
+        return $this->hydrator->hydrate($value, $instance);
+    }
+}

--- a/tests/GeneratedHydratorTest/ClassGenerator/AbstractHydratorGeneratorTest.php
+++ b/tests/GeneratedHydratorTest/ClassGenerator/AbstractHydratorGeneratorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydratorTest\ClassGenerator;
+
+use CodeGenerationUtils\GeneratorStrategy\EvaluatingGeneratorStrategy;
+use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
+use CodeGenerationUtils\Visitor\ClassRenamerVisitor;
+use GeneratedHydrator\ClassGenerator\AbstractHydratorGenerator;
+use GeneratedHydratorTestAsset\BaseClass;
+use GeneratedHydratorTestAsset\ClassWithByRefMagicMethods;
+use GeneratedHydratorTestAsset\ClassWithMagicMethods;
+use GeneratedHydratorTestAsset\ClassWithMixedProperties;
+use PhpParser\NodeTraverser;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Zend\Hydrator\HydratorInterface;
+
+/**
+ * Tests for {@see \GeneratedHydrator\ClassGenerator\HydratorGenerator}
+ *
+ * @covers \GeneratedHydrator\ClassGenerator\AbstractHydratorGenerator
+ */
+class AbstractHydratorGeneratorTest extends TestCase
+{
+    /**
+     * @dataProvider getTestedImplementations
+     *
+     * Verifies that generated code is valid and implements expected interfaces
+     */
+    public function testGeneratesValidCode(string $className) : void
+    {
+        $generator          = new AbstractHydratorGenerator();
+        $generatedClassName = UniqueIdentifierGenerator::getIdentifier('AbstractHydratorGeneratorTest');
+        $originalClass      = new ReflectionClass($className);
+        $generatorStrategy  = new EvaluatingGeneratorStrategy();
+        $traverser          = new NodeTraverser();
+
+        $traverser->addVisitor(new ClassRenamerVisitor($originalClass, $generatedClassName));
+        $generatorStrategy->generate($traverser->traverse($generator->generate($originalClass)));
+
+        $generatedReflection = new ReflectionClass($generatedClassName);
+
+        self::assertSame($generatedClassName, $generatedReflection->getName());
+
+        foreach ($this->getExpectedImplementedInterfaces() as $interface) {
+            self::assertTrue($generatedReflection->implementsInterface($interface));
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getTestedImplementations() : array
+    {
+        return [
+            [BaseClass::class],
+            [ClassWithMagicMethods::class],
+            [ClassWithByRefMagicMethods::class],
+            [ClassWithMixedProperties::class],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getExpectedImplementedInterfaces() : array
+    {
+        return [HydratorInterface::class];
+    }
+}

--- a/tests/GeneratedHydratorTest/CodeGenerator/Visitor/AbstractHydratorMethodsVisitorTest.php
+++ b/tests/GeneratedHydratorTest/CodeGenerator/Visitor/AbstractHydratorMethodsVisitorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydratorTest\CodeGenerator\Visitor;
+
+use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
+use GeneratedHydrator\CodeGenerator\Visitor\AbstractHydratorMethodsVisitor;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use function array_filter;
+
+/**
+ * Tests for {@see \GeneratedHydrator\CodeGenerator\Visitor\HydratorMethodsVisitor}
+ *
+ * @covers \GeneratedHydrator\CodeGenerator\Visitor\AbstractHydratorMethodsVisitor
+ */
+class AbstractHydratorMethodsVisitorTest extends TestCase
+{
+    /**
+     * @param string[] $properties
+     *
+     * @dataProvider classAstProvider
+     */
+    public function testBasicCodeGeneration(string $className, Class_ $classNode, array $properties) : void
+    {
+        $visitor = new AbstractHydratorMethodsVisitor(new ReflectionClass($className));
+
+        /** @var Class_ $modifiedAst */
+        $modifiedNode = $visitor->leaveNode($classNode);
+
+        self::assertMethodExistence('hydrate', $modifiedNode);
+        self::assertMethodExistence('extract', $modifiedNode);
+        self::assertMethodExistence('__construct', $modifiedNode);
+    }
+
+    /**
+     * Verifies that a method was correctly added to by the visitor
+     */
+    private function assertMethodExistence(string $methodName, Class_ $class) : void
+    {
+        $members = $class->stmts;
+
+        self::assertCount(
+            1,
+            array_filter(
+                $members,
+                static function (Node $node) use ($methodName) : bool {
+                    return $node instanceof ClassMethod
+                        && $methodName === $node->name->name;
+                }
+            )
+        );
+    }
+
+    /**
+     * @return Node[]
+     */
+    public function classAstProvider() : array
+    {
+        $parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7);
+
+        $className = UniqueIdentifierGenerator::getIdentifier('Foo');
+        $classCode = 'class ' . $className . ' { private $bar; private $baz; protected $tab; '
+            . 'protected $tar; public $taw; public $tam; }';
+
+        eval($classCode);
+
+        $staticClassName = UniqueIdentifierGenerator::getIdentifier('Foo');
+        $staticClassCode = 'class ' . $staticClassName . ' { private static $bar; '
+            . 'protected static $baz; public static $tab; private $taz; }';
+
+        eval($staticClassCode);
+
+        return [
+            [$className, $parser->parse('<?php ' . $classCode)[0], ['bar', 'baz', 'tab', 'tar', 'taw', 'tam']],
+            [$staticClassName, $parser->parse('<?php ' . $staticClassCode)[0], ['taz']],
+        ];
+    }
+}

--- a/tests/GeneratedHydratorTest/Functional/AbstractHydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/AbstractHydratorFunctionalTest.php
@@ -13,6 +13,7 @@ use GeneratedHydrator\Strategy\RecursiveHydrationStrategy;
 use GeneratedHydratorTestAsset\BaseClass;
 use GeneratedHydratorTestAsset\ClassWithMixedProperties;
 use GeneratedHydratorTestAsset\ClassWithObjectProperty;
+use GeneratedHydratorTestAsset\ClassWithPrivateObjectProperty;
 use GeneratedHydratorTestAsset\ClassWithPrivateProperties;
 use GeneratedHydratorTestAsset\ClassWithPrivatePropertiesAndParent;
 use GeneratedHydratorTestAsset\ClassWithPrivatePropertiesAndParents;
@@ -248,6 +249,63 @@ class AbstractHydratorFunctionalTest extends TestCase
                 'property9' => 'Prop9',
             ],
             'publicPropertiesCollection' => [
+                [
+                    'property0' => 'Prop10',
+                    'property1' => 'Prop11',
+                    'property2' => 'Prop12',
+                    'property3' => 'Prop13',
+                    'property4' => 'Prop14',
+                    'property5' => 'Prop15',
+                    'property6' => 'Prop16',
+                    'property7' => 'Prop17',
+                    'property8' => 'Prop18',
+                    'property9' => 'Prop19',
+                ],
+                [
+                    'property0' => 'Prop20',
+                    'property1' => 'Prop21',
+                    'property2' => 'Prop22',
+                    'property3' => 'Prop23',
+                    'property4' => 'Prop24',
+                    'property5' => 'Prop25',
+                    'property6' => 'Prop26',
+                    'property7' => 'Prop27',
+                    'property8' => 'Prop28',
+                    'property9' => 'Prop29',
+                ]
+            ],
+        ];
+
+        $hydrator->hydrate($reference, $instance);
+
+        self::assertSame($reference, $hydrator->extract($instance));
+    }
+
+    public function testHydratorWillHydratePrivatePropertiesWithStrategies(): void
+    {
+        $instance = new ClassWithPrivateObjectProperty();
+
+        $nestedHydrator = $this->generateHydrator(new ClassWithPrivateProperties());
+
+        /** @var AbstractHydrator $hydrator */
+        $hydrator = $this->generateHydrator($instance);
+        $hydrator->addStrategy('privateProperties', new RecursiveHydrationStrategy($nestedHydrator, ClassWithPrivateProperties::class));
+        $hydrator->addStrategy('privatePropertiesCollection', new RecursiveHydrationStrategy($nestedHydrator, ClassWithPrivateProperties::class, true));
+
+        $reference = [
+            'privateProperties' => [
+                'property0' => 'Prop0',
+                'property1' => 'Prop1',
+                'property2' => 'Prop2',
+                'property3' => 'Prop3',
+                'property4' => 'Prop4',
+                'property5' => 'Prop5',
+                'property6' => 'Prop6',
+                'property7' => 'Prop7',
+                'property8' => 'Prop8',
+                'property9' => 'Prop9',
+            ],
+            'privatePropertiesCollection' => [
                 [
                     'property0' => 'Prop10',
                     'property1' => 'Prop11',

--- a/tests/GeneratedHydratorTest/Functional/AbstractHydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/AbstractHydratorFunctionalTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydratorTest\Functional;
+
+use CodeGenerationUtils\GeneratorStrategy\EvaluatingGeneratorStrategy;
+use CodeGenerationUtils\Inflector\ClassNameInflectorInterface;
+use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
+use GeneratedHydrator\ClassGenerator\AbstractHydratorGenerator;
+use GeneratedHydrator\Configuration;
+use GeneratedHydrator\Strategy\RecursiveHydrationStrategy;
+use GeneratedHydratorTestAsset\BaseClass;
+use GeneratedHydratorTestAsset\ClassWithMixedProperties;
+use GeneratedHydratorTestAsset\ClassWithObjectProperty;
+use GeneratedHydratorTestAsset\ClassWithPrivateProperties;
+use GeneratedHydratorTestAsset\ClassWithPrivatePropertiesAndParent;
+use GeneratedHydratorTestAsset\ClassWithPrivatePropertiesAndParents;
+use GeneratedHydratorTestAsset\ClassWithProtectedProperties;
+use GeneratedHydratorTestAsset\ClassWithPublicProperties;
+use GeneratedHydratorTestAsset\ClassWithStaticProperties;
+use GeneratedHydratorTestAsset\ClassWithTypedProperties;
+use GeneratedHydratorTestAsset\EmptyClass;
+use GeneratedHydratorTestAsset\HydratedObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use stdClass;
+use Zend\Hydrator\AbstractHydrator;
+use Zend\Hydrator\HydratorInterface;
+use Zend\Hydrator\Strategy\ClosureStrategy;
+use function get_class;
+use function ksort;
+
+/**
+ * Tests for {@see \GeneratedHydrator\ClassGenerator\HydratorGenerator} produced objects
+ * @group Functional
+ */
+class AbstractHydratorFunctionalTest extends TestCase
+{
+    /**
+     * @dataProvider getHydratorClasses
+     */
+    public function testHydrator(object $instance): void
+    {
+        $reflection = new ReflectionClass($instance);
+        $initialData = [];
+        $newData = [];
+
+        $this->recursiveFindInitialData($reflection, $instance, $initialData, $newData);
+
+        $generatedClass = $this->generateHydrator($instance);
+
+        // Hydration and extraction don't guarantee ordering.
+        ksort($initialData);
+        ksort($newData);
+        $extracted = $generatedClass->extract($instance);
+        ksort($extracted);
+
+        self::assertSame($initialData, $extracted);
+        self::assertSame($instance, $generatedClass->hydrate($newData, $instance));
+
+        // Same as upper applies
+        $inspectionData = [];
+        $this->recursiveFindInspectionData($reflection, $instance, $inspectionData);
+        ksort($inspectionData);
+        $extracted = $generatedClass->extract($instance);
+        ksort($extracted);
+
+        self::assertSame($inspectionData, $newData);
+        self::assertSame($inspectionData, $extracted);
+    }
+
+    /**
+     * Recursively populate the $initialData and $newData array browsing the
+     * full class hierarchy tree
+     * Private properties from parent class that are hidden by children will be
+     * dropped from the populated arrays
+     *
+     * @param mixed[] $initialData
+     * @param mixed[] $newData
+     */
+    private function recursiveFindInitialData(
+        ReflectionClass $class,
+        object $instance,
+        array &$initialData,
+        array &$newData
+    ): void {
+        $parentClass = $class->getParentClass();
+        if ($parentClass) {
+            $this->recursiveFindInitialData($parentClass, $instance, $initialData, $newData);
+        }
+
+        foreach ($class->getProperties() as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $propertyName = $property->getName();
+
+            $property->setAccessible(true);
+            $initialData[$propertyName] = $property->getValue($instance);
+            $newData[$propertyName] = $property->getName() . '__new__value';
+        }
+    }
+
+    /**
+     * Generates a hydrator for the given class name, and retrieves its class name
+     */
+    private function generateHydrator(object $instance): HydratorInterface
+    {
+        $parentClassName = get_class($instance);
+        $generatedClassName = __NAMESPACE__ . '\\' . UniqueIdentifierGenerator::getIdentifier('Foo');
+        $config = new Configuration($parentClassName);
+        $config->setHydratorGenerator(new AbstractHydratorGenerator());
+        /** @var ClassNameInflectorInterface|MockObject $inflector */
+        $inflector = $this->createMock(ClassNameInflectorInterface::class);
+
+        $inflector
+            ->expects(self::any())
+            ->method('getGeneratedClassName')
+            ->with($parentClassName)
+            ->will(self::returnValue($generatedClassName));
+        $inflector
+            ->expects(self::any())
+            ->method('getUserClassName')
+            ->with($parentClassName)
+            ->will(self::returnValue($parentClassName));
+
+        $config->setClassNameInflector($inflector);
+        $config->setGeneratorStrategy(new EvaluatingGeneratorStrategy());
+
+        $generatedClass = $config->createFactory()->getHydratorClass();
+
+        return new $generatedClass();
+    }
+
+    /**
+     * Recursively populate the $inspectedData array browsing the full class
+     * hierarchy tree
+     * Private properties from parent class that are hidden by children will be
+     * dropped from the populated arrays
+     *
+     * @param mixed[] $inspectionData
+     */
+    private function recursiveFindInspectionData(
+        ReflectionClass $class,
+        object $instance,
+        array &$inspectionData
+    ): void {
+        $parentClass = $class->getParentClass();
+        if ($parentClass) {
+            $this->recursiveFindInspectionData($parentClass, $instance, $inspectionData);
+        }
+
+        foreach ($class->getProperties() as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $propertyName = $property->getName();
+
+            $property->setAccessible(true);
+            $inspectionData[$propertyName] = $property->getValue($instance);
+        }
+    }
+
+    public function testHydratingNull(): void
+    {
+        $instance = new ClassWithPrivateProperties();
+
+        self::assertSame('property0', $instance->getProperty0());
+
+        $this->generateHydrator($instance)->hydrate(['property0' => null], $instance);
+
+        self::assertNull($instance->getProperty0());
+    }
+
+    /**
+     * Ensures that the hydrator will not attempt to read unitialized PHP >= 7.4
+     * typed property, which would cause "Uncaught Error: Typed property Foo::$a
+     * must not be accessed before initialization" PHP engine errors.
+     * @requires PHP >= 7.4
+     */
+    public function testHydratorWillNotRaisedUnitiliazedTypedPropertyAccessError(): void
+    {
+        $instance = new ClassWithTypedProperties();
+        $hydrator = $this->generateHydrator($instance);
+
+        $hydrator->hydrate(['property2' => 3], $instance);
+
+        self::assertSame([
+            'property0' => 1, // 'property0' has a default value, it should keep it.
+            'property1' => 2, // 'property1' has a default value, it should keep it.
+            'property2' => 3,
+            'property3' => null, // 'property3' is not required, it should remain null.
+            'property4' => null, // 'property4' default value is null, it should remain null.
+            'untyped0' => null, // 'untyped0' is null by default
+            'untyped1' => null, // 'untyped1' is null by default
+        ], $hydrator->extract($instance));
+    }
+
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function testHydratorWillSetAllTypedProperties(): void
+    {
+        $instance = new ClassWithTypedProperties();
+        $hydrator = $this->generateHydrator($instance);
+
+        $reference = [
+            'property0' => 11,
+            'property1' => null, // Ensure explicit set null works as expected.
+            'property2' => 13,
+            'property3' => null, // Different use case (unrequired value with no default value).
+            'property4' => 19,
+            'untyped0' => null, // 'untyped0' is null by default
+            'untyped1' => null, // 'untyped1' is null by default
+        ];
+
+        $hydrator->hydrate($reference, $instance);
+
+        self::assertSame($reference, $hydrator->extract($instance));
+    }
+
+    public function testHydratorWillHydrateWithStrategies(): void
+    {
+        $instance = new ClassWithObjectProperty();
+
+        $nestedHydrator = $this->generateHydrator(new ClassWithPublicProperties());
+
+        /** @var AbstractHydrator $hydrator */
+        $hydrator = $this->generateHydrator($instance);
+        $hydrator->addStrategy('publicProperties', new RecursiveHydrationStrategy($nestedHydrator, ClassWithPublicProperties::class));
+        $hydrator->addStrategy('publicPropertiesCollection', new RecursiveHydrationStrategy($nestedHydrator, ClassWithPublicProperties::class, true));
+
+        $reference = [
+            'publicProperties' => [
+                'property0' => 'Prop0',
+                'property1' => 'Prop1',
+                'property2' => 'Prop2',
+                'property3' => 'Prop3',
+                'property4' => 'Prop4',
+                'property5' => 'Prop5',
+                'property6' => 'Prop6',
+                'property7' => 'Prop7',
+                'property8' => 'Prop8',
+                'property9' => 'Prop9',
+            ],
+            'publicPropertiesCollection' => [
+                [
+                    'property0' => 'Prop10',
+                    'property1' => 'Prop11',
+                    'property2' => 'Prop12',
+                    'property3' => 'Prop13',
+                    'property4' => 'Prop14',
+                    'property5' => 'Prop15',
+                    'property6' => 'Prop16',
+                    'property7' => 'Prop17',
+                    'property8' => 'Prop18',
+                    'property9' => 'Prop19',
+                ],
+                [
+                    'property0' => 'Prop20',
+                    'property1' => 'Prop21',
+                    'property2' => 'Prop22',
+                    'property3' => 'Prop23',
+                    'property4' => 'Prop24',
+                    'property5' => 'Prop25',
+                    'property6' => 'Prop26',
+                    'property7' => 'Prop27',
+                    'property8' => 'Prop28',
+                    'property9' => 'Prop29',
+                ]
+            ],
+        ];
+
+        $hydrator->hydrate($reference, $instance);
+
+        self::assertSame($reference, $hydrator->extract($instance));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getHydratorClasses(): array
+    {
+        return [
+            [new stdClass()],
+            [new EmptyClass()],
+            [new HydratedObject()],
+            [new BaseClass()],
+            [new ClassWithPublicProperties()],
+            [new ClassWithProtectedProperties()],
+            [new ClassWithPrivateProperties()],
+            [new ClassWithPrivatePropertiesAndParent()],
+            [new ClassWithPrivatePropertiesAndParents()],
+            [new ClassWithMixedProperties()],
+            [new ClassWithStaticProperties()],
+        ];
+    }
+}

--- a/tests/GeneratedHydratorTestAsset/ClassWithObjectProperty.php
+++ b/tests/GeneratedHydratorTestAsset/ClassWithObjectProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydratorTestAsset;
+
+/**
+ * Base test class to play around with public properties
+ */
+class ClassWithObjectProperty
+{
+    /** @var ClassWithPublicProperties|null */
+    public $publicProperties;
+
+    /** @var ClassWithPublicProperties[] */
+    public array $publicPropertiesCollection = [];
+}

--- a/tests/GeneratedHydratorTestAsset/ClassWithPrivateObjectProperty.php
+++ b/tests/GeneratedHydratorTestAsset/ClassWithPrivateObjectProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydratorTestAsset;
+
+/**
+ * Base test class to play around with public properties
+ */
+class ClassWithPrivateObjectProperty
+{
+    /** @var ClassWithPrivateProperties|null */
+    private $privateProperties;
+
+    /** @var ClassWithPrivateProperties[] */
+    private array $privatePropertiesCollection = [];
+}


### PR DESCRIPTION
To allow the usage of Strategies, I implemented a CodeGenerator to use the AbstractHydrator as the base class. In that way, it's also possible to hydrate recursively with the new RecursiveHydrationStrategy, which is also part of this Pull-Request.