### PR TITLE
Added support for a "MappedFrom" annotation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,11 @@
         }
     ],
     "require": {
-        "php":                           "^7.4",
-        "nikic/php-parser":              "^4.6.0",
-        "ocramius/code-generator-utils": "^1.0.0",
-        "laminas/laminas-hydrator":      "^2.4.1"
+        "php": "^7.4",
+        "doctrine/annotations": "^1.10",
+        "laminas/laminas-hydrator": "^2.4.1",
+        "nikic/php-parser": "^4.6.0",
+        "ocramius/code-generator-utils": "^1.0.0"
     },
     "require-dev": {
         "doctrine/coding-standard":           "^7.0.2",
@@ -34,6 +35,9 @@
         "laminas/laminas-filter":                "^2.9.2",
         "laminas/laminas-servicemanager":     "^3.4.0",
         "laminas/laminas-stdlib":             "^3.2.1"
+    },
+    "suggest": {
+        "doctrine/annotations": "Needed to support the 'MappedFrom' annotation."
     },
     "autoload": {
         "psr-4": {

--- a/src/GeneratedHydrator/Annotation/MappedFrom.php
+++ b/src/GeneratedHydrator/Annotation/MappedFrom.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydrator\Annotation;
+
+/** @Annotation */
+final class MappedFrom
+{
+    /** @psalm-var non-empty-string */
+    public string $name;
+}

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -104,7 +104,7 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
     private function generatePropertyHydrateCall(ObjectProperty $property, string $inputArrayName) : array
     {
         $propertyName = $property->name;
-        $escapedName  = var_export($propertyName, true);
+        $escapedName  = var_export($property->mappedFrom, true);
 
         if ($property->allowsNull && ! $property->hasDefault) {
             return ['$object->' . $propertyName . ' = ' . $inputArrayName . '[' . $escapedName . '] ?? null;'];

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/ObjectProperty.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/ObjectProperty.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace GeneratedHydrator\CodeGenerator\Visitor;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use GeneratedHydrator\Annotation\MappedFrom;
 use ReflectionProperty;
 use function array_key_exists;
+use function class_exists;
 
 /**
  * @internal
@@ -19,32 +22,43 @@ final class ObjectProperty
     public bool $allowsNull;
     /** @psalm-var non-empty-string */
     public string $name;
+    /** @psalm-var non-empty-string */
+    public string $mappedFrom;
 
     /** @psalm-param non-empty-string $name */
-    private function __construct(string $name, bool $hasType, bool $allowsNull, bool $hasDefault)
+    private function __construct(string $name, bool $hasType, bool $allowsNull, bool $hasDefault, string $mappedFrom)
     {
         $this->name       = $name;
         $this->hasType    = $hasType;
         $this->allowsNull = $allowsNull;
         $this->hasDefault = $hasDefault;
+        $this->mappedFrom = $mappedFrom;
     }
 
     public static function fromReflection(ReflectionProperty $property) : self
     {
         /** @psalm-var non-empty-string $propertyName */
         $propertyName  = $property->getName();
+        $mappedFrom  = $property->getName();
         $type          = $property->getType();
         $defaultValues = $property->getDeclaringClass()->getDefaultProperties();
 
+        if (class_exists(AnnotationReader::class) === true) {
+            $reader = new AnnotationReader();
+            $mappedFromAnnotation = $reader->getPropertyAnnotation($property, MappedFrom::class);
+            $mappedFrom = $mappedFromAnnotation->name ?? $propertyName;
+        }
+
         if ($type === null) {
-            return new self($propertyName, false, true, array_key_exists($propertyName, $defaultValues));
+            return new self($propertyName, false, true, array_key_exists($propertyName, $defaultValues), $mappedFrom);
         }
 
         return new self(
             $propertyName,
             true,
             $type->allowsNull(),
-            array_key_exists($propertyName, $defaultValues)
+            array_key_exists($propertyName, $defaultValues),
+            $mappedFrom
         );
     }
 }

--- a/tests/GeneratedHydratorTest/CodeGenerator/Visitor/ObjectPropertyTest.php
+++ b/tests/GeneratedHydratorTest/CodeGenerator/Visitor/ObjectPropertyTest.php
@@ -19,6 +19,7 @@ class ObjectPropertyTest extends TestCase
         $property2 = ObjectProperty::fromReflection(new ReflectionProperty(ClassWithTypedProperties::class, 'property2'));
         $property3 = ObjectProperty::fromReflection(new ReflectionProperty(ClassWithTypedProperties::class, 'property3'));
         $property4 = ObjectProperty::fromReflection(new ReflectionProperty(ClassWithTypedProperties::class, 'property4'));
+        $property5 = ObjectProperty::fromReflection(new ReflectionProperty(ClassWithTypedProperties::class, 'property5'));
         $untyped0  = ObjectProperty::fromReflection(new ReflectionProperty(ClassWithTypedProperties::class, 'untyped0'));
         $untyped1  = ObjectProperty::fromReflection(new ReflectionProperty(ClassWithTypedProperties::class, 'untyped1'));
 
@@ -27,8 +28,17 @@ class ObjectPropertyTest extends TestCase
         self::assertSame('property2', $property2->name);
         self::assertSame('property3', $property3->name);
         self::assertSame('property4', $property4->name);
+        self::assertSame('property5', $property5->name);
         self::assertSame('untyped0', $untyped0->name);
         self::assertSame('untyped1', $untyped1->name);
+
+        self::assertSame('property0', $property0->mappedFrom);
+        self::assertSame('property1', $property1->mappedFrom);
+        self::assertSame('property2', $property2->mappedFrom);
+        self::assertSame('property3', $property3->mappedFrom);
+        self::assertSame('property4', $property4->mappedFrom);
+        self::assertSame('untyped0', $untyped0->mappedFrom);
+        self::assertSame('untyped1', $untyped1->mappedFrom);
 
         self::assertTrue($property0->hasType);
         self::assertTrue($property1->hasType);

--- a/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
@@ -9,6 +9,7 @@ use CodeGenerationUtils\Inflector\ClassNameInflectorInterface;
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 use GeneratedHydrator\Configuration;
 use GeneratedHydratorTestAsset\BaseClass;
+use GeneratedHydratorTestAsset\ClassWithMappedProperties;
 use GeneratedHydratorTestAsset\ClassWithMixedProperties;
 use GeneratedHydratorTestAsset\ClassWithPrivateProperties;
 use GeneratedHydratorTestAsset\ClassWithPrivatePropertiesAndParent;
@@ -99,8 +100,27 @@ class HydratorFunctionalTest extends TestCase
             'property3' => null, // 'property3' is not required, it should remain null.
             'property4' => null, // 'property4' default value is null, it should remain null.
             'untyped0' => null, // 'untyped0' is null by default
-            'untyped1' => null, // 'untyped1' is null by default
+            'untyped1' => null, // 'untyped1' is null by default,
+            'property5' => 'test'
         ], $hydrator->extract($instance));
+    }
+
+    public function testHydratorWithMappedFromAnnotation() : void
+    {
+        $instance = new ClassWithMappedProperties();
+        $hydrator = $this->generateHydrator($instance);
+
+        $hydratedInstance = $hydrator->hydrate([
+            'test0' => 9,
+            'test1' => 8,
+            'test2' => 7,
+            'test3' => 6,
+        ], $instance);
+
+        self::assertSame(9, $hydratedInstance->property0);
+        self::assertSame(8, $hydratedInstance->property1);
+        self::assertSame(7, $hydratedInstance->property2);
+        self::assertSame(6, $hydratedInstance->property3);
     }
 
     /**
@@ -119,6 +139,7 @@ class HydratorFunctionalTest extends TestCase
             'property4' => 19,
             'untyped0' => null, // 'untyped0' is null by default
             'untyped1' => null, // 'untyped1' is null by default
+            'property5' => 'test'
         ];
 
         $hydrator->hydrate($reference, $instance);

--- a/tests/GeneratedHydratorTestAsset/ClassWithMappedProperties.php
+++ b/tests/GeneratedHydratorTestAsset/ClassWithMappedProperties.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneratedHydratorTestAsset;
+
+use GeneratedHydrator\Annotation\MappedFrom;
+
+final class ClassWithMappedProperties
+{
+    /** @MappedFrom(name="test0") */
+    public int $property0;
+    /** @MappedFrom(name="test1") */
+    public ?int $property1;
+    /** @MappedFrom(name="test2") */
+    public int $property2 = 3;
+    /** @MappedFrom(name="test3") */
+    public $property3;
+}

--- a/tests/GeneratedHydratorTestAsset/ClassWithTypedProperties.php
+++ b/tests/GeneratedHydratorTestAsset/ClassWithTypedProperties.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GeneratedHydratorTestAsset;
 
+use GeneratedHydrator\Annotation\MappedFrom;
+
 /**
  * Test PHP 7.4 hydration and dehydration.
  */
@@ -18,4 +20,6 @@ final class ClassWithTypedProperties
     private $untyped0;
     /** @var mixed */
     private $untyped1 = null;
+    /** @MappedFrom(name="property_5") */
+    private string $property5 = 'test';
 }


### PR DESCRIPTION
Hey,

Sometimes the array of data doesn't exactly match the property name of the class i'd like to hydrate. This PR aims to solve this by adding a "MappedFrom" annotation which allows you to optionally define a custom key name.

Example:

```PHP
$data = [
    'property_1' => 'test'
];

class Data {
    /**
     * @MappedFrom(name="property_1")
     */
    public string $property1;
}

$hydrator->hydrate($data, new Data());
```

I'd love to know what you think.

Thanks.