### PR TITLE
#126: Fixes issues reading/writing typed properties which are uninitialised

### DIFF
--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -145,9 +145,9 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
             // Extract closures
             $bodyParts[] = '$this->extractCallbacks[] = \\Closure::bind(static function ($object, &$values) {';
             foreach ($properties as $property) {
-                $propertyName = $property->name;
-                $requiresGuard = $property->hasType && !($property->hasDefault || $property->allowsNull);
-                $indent = $requiresGuard ? '        ' : '    ';
+                $propertyName  = $property->name;
+                $requiresGuard = $property->hasType && ! ($property->hasDefault || $property->allowsNull);
+                $indent        = $requiresGuard ? '        ' : '    ';
 
                 if ($requiresGuard) {
                     $bodyParts[] = '    if (isset($object->' . $propertyName . ')) {';

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -121,16 +121,15 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
 
     /**
      * @return string[]
-     *
      * @psalm-return list<string>
      */
     private function generatePropertyExtractCall(ObjectProperty $property): array
     {
         $propertyName        = $property->name;
         $assignmentStatement = sprintf('    $values[\'%s\'] = $object->%1$s;', $propertyName);
-        $requiresGuard       = $property->hasType && !($property->hasDefault || $property->allowsNull);
+        $requiresGuard       = $property->hasType && ! ($property->hasDefault || $property->allowsNull);
 
-        if (!$requiresGuard) {
+        if (! $requiresGuard) {
             return [$assignmentStatement];
         }
 

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/ObjectProperty.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/ObjectProperty.php
@@ -15,13 +15,9 @@ use function array_key_exists;
  */
 final class ObjectProperty
 {
-    /** @psalm-var non-empty-string */
-    public string $name;
-
     /** @psalm-param non-empty-string $name */
-    private function __construct(string $name, public bool $hasType, public bool $allowsNull, public bool $hasDefault)
+    private function __construct(public string $name, public bool $hasType, public bool $allowsNull, public bool $hasDefault)
     {
-        $this->name = $name;
     }
 
     public static function fromReflection(ReflectionProperty $property): self

--- a/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
@@ -100,6 +100,30 @@ class HydratorFunctionalTest extends TestCase
         ], $hydrator->extract($instance));
     }
 
+    /**
+     * Ensures that the hydrator will not attempt to read unitialized PHP >= 7.4
+     * typed property, which would cause "Uncaught Error: Typed property Foo::$a
+     * must not be accessed before initialization" PHP engine errors.
+     *
+     * @requires PHP >= 7.4
+     */
+    public function testHydratorWillNotRaisedUnitiliazedTypedPropertyAccessErrorIfPropertyIsntHydrated(): void
+    {
+        $instance = new ClassWithTypedProperties();
+        $hydrator = $this->generateHydrator($instance);
+
+        $hydrator->hydrate(['untyped0' => 3], $instance);
+
+        self::assertSame([
+            'property0' => 1, // 'property0' has a default value, it should keep it.
+            'property1' => 2, // 'property1' has a default value, it should keep it.
+            'property3' => null, // 'property3' is not required, it should remain null.
+            'property4' => null, // 'property4' default value is null, it should remain null.
+            'untyped0' => 3, // 'untyped0' is null by default
+            'untyped1' => null, // 'untyped1' is null by default
+        ], $hydrator->extract($instance));
+    }
+
     /** @requires PHP >= 7.4 */
     public function testHydratorWillSetAllTypedProperties(): void
     {

--- a/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
@@ -79,8 +79,6 @@ class HydratorFunctionalTest extends TestCase
      * Ensures that the hydrator will not attempt to read unitialized PHP >= 7.4
      * typed property, which would cause "Uncaught Error: Typed property Foo::$a
      * must not be accessed before initialization" PHP engine errors.
-     *
-     * @requires PHP >= 7.4
      */
     public function testHydratorWillNotRaisedUnitiliazedTypedPropertyAccessError(): void
     {
@@ -104,8 +102,6 @@ class HydratorFunctionalTest extends TestCase
      * Ensures that the hydrator will not attempt to read unitialized PHP >= 7.4
      * typed property, which would cause "Uncaught Error: Typed property Foo::$a
      * must not be accessed before initialization" PHP engine errors.
-     *
-     * @requires PHP >= 7.4
      */
     public function testHydratorWillNotRaisedUnitiliazedTypedPropertyAccessErrorIfPropertyIsntHydrated(): void
     {
@@ -124,7 +120,6 @@ class HydratorFunctionalTest extends TestCase
         ], $hydrator->extract($instance));
     }
 
-    /** @requires PHP >= 7.4 */
     public function testHydratorWillSetAllTypedProperties(): void
     {
         $instance = new ClassWithTypedProperties();


### PR DESCRIPTION
#126 documents an issue with the generated hydrator failing with an error when trying to hydrate an object containing typed properties when a typed property is not present in the data array passed to the hydrator, contains no default value and cannot be null. 

The fix is to check that the property isset before attempting to do the null check (hydration) or read from the property (extraction). Extraction behaviour for an unset property is not to include the property in the extracted payload; this is to ensure that the behaviour of chained $hydrator->extract() and $hydrator->hydrate() calls continues to work as expected since keeping the property in the array but leaving it null would cause the hydrate call to attempt to set the property to null, this is undesirable as the property type definition doesn't include null and would cause an error.

Have targetted against 4.1.x as this is a bug introduced by PHP 7.4 and this is the most recent version which supports PHP 7.4

This code could be considered a BC break as an operation which previously resulted in an error will now operate correctly, however there are very few scenarios that I can think of where this would cause someone an issue, since using hydration as a means of data validation would be a pretty suspect use case. 

Fixes #126 