### PR TITLE
issue #126 - don't crash on uninitialized properties

### DIFF
--- a/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
+++ b/tests/GeneratedHydratorTest/Functional/HydratorFunctionalTest.php
@@ -100,6 +100,28 @@ class HydratorFunctionalTest extends TestCase
         ], $hydrator->extract($instance));
     }
 
+    /**
+     * Ensures that the hydrator will not attempt to read unitialized PHP >= 7.4
+     * typed property, which would cause "Uncaught Error: Typed property Foo::$a
+     * must not be accessed before initialization" PHP engine errors.
+     */
+    public function testHydratorWillNotRaisedUnitiliazedTypedPropertyAccessErrorIfPropertyIsntHydrated(): void
+    {
+        $instance = new ClassWithTypedProperties();
+        $hydrator = $this->generateHydrator($instance);
+
+        $hydrator->hydrate(['untyped0' => 3], $instance);
+
+        self::assertSame([
+            'property0' => 1, // 'property0' has a default value, it should keep it.
+            'property1' => 2, // 'property1' has a default value, it should keep it.
+            'property3' => null, // 'property3' is not required, it should remain null.
+            'property4' => null, // 'property4' default value is null, it should remain null.
+            'untyped0' => 3, // 'untyped0' is null by default
+            'untyped1' => null, // 'untyped1' is null by default
+        ], $hydrator->extract($instance));
+    }
+
     /** @requires PHP >= 7.4 */
     public function testHydratorWillSetAllTypedProperties(): void
     {


### PR DESCRIPTION
I took the liberty of creating a duplicate of https://github.com/Ocramius/GeneratedHydrator/pull/370 that fixes #126.

I have copy/pasted code from the former, but changed the way the guard is implemented by simply writing the extract this way:

```php
try {
    $ret['possibly_unitialized_property'] = $object->possibly_unitialized_property;
} catch (\Error) {}
```

Hiding engine errors is probably a terrible thing to do, although it works.

There is a question remaining open, should we instead write this ?

```php
try {
    $ret['possibly_unitialized_property'] = $object->possibly_unitialized_property;
} catch (\Error) {
    $ret['possibly_unitialized_property'] = null;
}
```

I guess simply not setting the value in the array is more representative of what is happening: the value don't get set in the array since it wasn't set at all in the object. I don't care which is the best, both will work for most my use cases, or can be worked around easily.